### PR TITLE
feat: 프론트엔드 백엔드 연동 추가 및 마이페이지/입찰 기능 보완

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,53 +1,27 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
+import { RouterView, useRoute, useRouter } from 'vue-router'
 import AppShell from './components/AppShell.vue'
-import AuctionDetailScreen from './components/AuctionDetailScreen.vue'
-import AuctionListScreen from './components/AuctionListScreen.vue'
-import HomeScreen from './components/HomeScreen.vue'
-import InspectionScreen from './components/InspectionScreen.vue'
-import MyPageScreen from './components/MyPageScreen.vue'
-import RegisterScreen from './components/RegisterScreen.vue'
 import {
   assets,
-  bestItems,
-  categoryGroups,
-  inspectionItems,
-  inspectionSummary,
-  listItems,
-  mypageBidItems,
   mypageNavigationItems,
-  mypageProfile,
-  mypagePurchaseItems,
   navigationItems,
 } from './data/marketplaceData'
 
-const currentScreen = ref('home')
-const selectedItem = ref(null)
-const registerEntryMode = ref('select')
+const route = useRoute()
+const router = useRouter()
 
 const activeNavigationItems = computed(() =>
-  currentScreen.value === 'mypage' ? mypageNavigationItems : navigationItems,
+  route.meta.navSection === 'mypage' ? mypageNavigationItems : navigationItems,
 )
 
-const currentNavKey = computed(() =>
-  currentScreen.value === 'mypage' ? 'mypage-dashboard' : currentScreen.value,
-)
+const currentNavKey = computed(() => String(route.meta.navKey ?? ''))
+const currentScreen = computed(() => String(route.name ?? ''))
 
-function openScreen(screen) {
-  if (screen === 'home' || screen === 'list' || screen === 'register' || screen === 'inspection' || screen === 'mypage') {
-    registerEntryMode.value = screen === 'register' ? 'select' : registerEntryMode.value
-    currentScreen.value = screen
+function navigate(path) {
+  if (typeof path === 'string' && path) {
+    router.push(path)
   }
-}
-
-function openRegister(mode = 'select') {
-  registerEntryMode.value = mode
-  currentScreen.value = 'register'
-}
-
-function openDetail(item) {
-  selectedItem.value = item
-  currentScreen.value = 'detail'
 }
 </script>
 
@@ -57,51 +31,9 @@ function openDetail(item) {
     :current-screen="currentScreen"
     :current-nav-key="currentNavKey"
     :navigation-items="activeNavigationItems"
-    @navigate="openScreen"
-    @open-mypage="openScreen('mypage')"
+    @navigate="navigate"
+    @open-mypage="navigate('/mypage')"
   >
-    <HomeScreen
-      v-if="currentScreen === 'home'"
-      :assets="assets"
-      :items="bestItems"
-      @open-detail="openDetail"
-      @open-list="openScreen('list')"
-    />
-
-    <AuctionListScreen
-      v-else-if="currentScreen === 'list'"
-      :assets="assets"
-      :categories="categoryGroups"
-      :items="listItems"
-      @open-detail="openDetail"
-    />
-
-    <AuctionDetailScreen
-      v-else-if="currentScreen === 'detail' && selectedItem"
-      :assets="assets"
-      :item="selectedItem"
-      @back="openScreen('list')"
-    />
-
-    <RegisterScreen
-      v-else-if="currentScreen === 'register'"
-      :initial-mode="registerEntryMode"
-    />
-
-    <InspectionScreen
-      v-else-if="currentScreen === 'inspection'"
-      :assets="assets"
-      :items="inspectionItems"
-      :summary="inspectionSummary"
-      @open-register="openRegister"
-    />
-
-    <MyPageScreen
-      v-else-if="currentScreen === 'mypage'"
-      :assets="assets"
-      :profile="mypageProfile"
-      :bid-items="mypageBidItems"
-      :purchase-items="mypagePurchaseItems"
-    />
+    <RouterView />
   </AppShell>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import AppShell from './components/AppShell.vue'
 import AuctionDetailScreen from './components/AuctionDetailScreen.vue'
 import AuctionListScreen from './components/AuctionListScreen.vue'
 import HomeScreen from './components/HomeScreen.vue'
 import InspectionScreen from './components/InspectionScreen.vue'
+import MyPageScreen from './components/MyPageScreen.vue'
 import RegisterScreen from './components/RegisterScreen.vue'
 import {
   assets,
@@ -13,6 +14,10 @@ import {
   inspectionItems,
   inspectionSummary,
   listItems,
+  mypageBidItems,
+  mypageNavigationItems,
+  mypageProfile,
+  mypagePurchaseItems,
   navigationItems,
 } from './data/marketplaceData'
 
@@ -20,8 +25,16 @@ const currentScreen = ref('home')
 const selectedItem = ref(null)
 const registerEntryMode = ref('select')
 
+const activeNavigationItems = computed(() =>
+  currentScreen.value === 'mypage' ? mypageNavigationItems : navigationItems,
+)
+
+const currentNavKey = computed(() =>
+  currentScreen.value === 'mypage' ? 'mypage-dashboard' : currentScreen.value,
+)
+
 function openScreen(screen) {
-  if (screen === 'home' || screen === 'list' || screen === 'register' || screen === 'inspection') {
+  if (screen === 'home' || screen === 'list' || screen === 'register' || screen === 'inspection' || screen === 'mypage') {
     registerEntryMode.value = screen === 'register' ? 'select' : registerEntryMode.value
     currentScreen.value = screen
   }
@@ -42,8 +55,10 @@ function openDetail(item) {
   <AppShell
     :assets="assets"
     :current-screen="currentScreen"
-    :navigation-items="navigationItems"
+    :current-nav-key="currentNavKey"
+    :navigation-items="activeNavigationItems"
     @navigate="openScreen"
+    @open-mypage="openScreen('mypage')"
   >
     <HomeScreen
       v-if="currentScreen === 'home'"
@@ -79,6 +94,14 @@ function openDetail(item) {
       :items="inspectionItems"
       :summary="inspectionSummary"
       @open-register="openRegister"
+    />
+
+    <MyPageScreen
+      v-else-if="currentScreen === 'mypage'"
+      :assets="assets"
+      :profile="mypageProfile"
+      :bid-items="mypageBidItems"
+      :purchase-items="mypagePurchaseItems"
     />
   </AppShell>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,16 +14,22 @@ import {
   inspectionSummary,
   listItems,
   navigationItems,
-  registerOptions,
 } from './data/marketplaceData'
 
 const currentScreen = ref('home')
 const selectedItem = ref(null)
+const registerEntryMode = ref('select')
 
 function openScreen(screen) {
   if (screen === 'home' || screen === 'list' || screen === 'register' || screen === 'inspection') {
+    registerEntryMode.value = screen === 'register' ? 'select' : registerEntryMode.value
     currentScreen.value = screen
   }
+}
+
+function openRegister(mode = 'select') {
+  registerEntryMode.value = mode
+  currentScreen.value = 'register'
 }
 
 function openDetail(item) {
@@ -64,7 +70,7 @@ function openDetail(item) {
 
     <RegisterScreen
       v-else-if="currentScreen === 'register'"
-      :options="registerOptions"
+      :initial-mode="registerEntryMode"
     />
 
     <InspectionScreen
@@ -72,6 +78,7 @@ function openDetail(item) {
       :assets="assets"
       :items="inspectionItems"
       :summary="inspectionSummary"
+      @open-register="openRegister"
     />
   </AppShell>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,77 @@
 <script setup>
+import { ref } from 'vue'
+import AppShell from './components/AppShell.vue'
+import AuctionDetailScreen from './components/AuctionDetailScreen.vue'
+import AuctionListScreen from './components/AuctionListScreen.vue'
+import HomeScreen from './components/HomeScreen.vue'
+import InspectionScreen from './components/InspectionScreen.vue'
+import RegisterScreen from './components/RegisterScreen.vue'
+import {
+  assets,
+  bestItems,
+  categoryGroups,
+  inspectionItems,
+  inspectionSummary,
+  listItems,
+  navigationItems,
+  registerOptions,
+} from './data/marketplaceData'
+
+const currentScreen = ref('home')
+const selectedItem = ref(null)
+
+function openScreen(screen) {
+  if (screen === 'home' || screen === 'list' || screen === 'register' || screen === 'inspection') {
+    currentScreen.value = screen
+  }
+}
+
+function openDetail(item) {
+  selectedItem.value = item
+  currentScreen.value = 'detail'
+}
 </script>
 
 <template>
-  테스트
+  <AppShell
+    :assets="assets"
+    :current-screen="currentScreen"
+    :navigation-items="navigationItems"
+    @navigate="openScreen"
+  >
+    <HomeScreen
+      v-if="currentScreen === 'home'"
+      :assets="assets"
+      :items="bestItems"
+      @open-detail="openDetail"
+      @open-list="openScreen('list')"
+    />
+
+    <AuctionListScreen
+      v-else-if="currentScreen === 'list'"
+      :assets="assets"
+      :categories="categoryGroups"
+      :items="listItems"
+      @open-detail="openDetail"
+    />
+
+    <AuctionDetailScreen
+      v-else-if="currentScreen === 'detail' && selectedItem"
+      :assets="assets"
+      :item="selectedItem"
+      @back="openScreen('list')"
+    />
+
+    <RegisterScreen
+      v-else-if="currentScreen === 'register'"
+      :options="registerOptions"
+    />
+
+    <InspectionScreen
+      v-else-if="currentScreen === 'inspection'"
+      :assets="assets"
+      :items="inspectionItems"
+      :summary="inspectionSummary"
+    />
+  </AppShell>
 </template>

--- a/src/components/AppShell.vue
+++ b/src/components/AppShell.vue
@@ -8,13 +8,17 @@ defineProps({
     type: String,
     required: true,
   },
+  currentNavKey: {
+    type: String,
+    default: '',
+  },
   navigationItems: {
     type: Array,
     required: true,
   },
 })
 
-defineEmits(['navigate'])
+defineEmits(['navigate', 'open-mypage'])
 </script>
 
 <template>
@@ -31,8 +35,8 @@ defineEmits(['navigate'])
           :key="item.label"
           type="button"
           class="nav-item"
-          :class="{ 'is-active': currentScreen === item.key }"
-          @click="$emit('navigate', item.key)"
+          :class="{ 'is-active': currentNavKey === item.key || (!currentNavKey && currentScreen === item.key) }"
+          @click="$emit('navigate', item.route ?? item.key)"
         >
           <img :src="item.icon" :alt="item.label" class="nav-icon" />
           <span>{{ item.label }}</span>
@@ -48,7 +52,7 @@ defineEmits(['navigate'])
         </div>
 
         <div class="top-links">
-          <button type="button">마이페이지</button>
+          <button type="button" @click="$emit('open-mypage')">마이페이지</button>
           <button type="button">알림</button>
           <button type="button">로그인/회원가입</button>
         </div>

--- a/src/components/AppShell.vue
+++ b/src/components/AppShell.vue
@@ -1,0 +1,62 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  currentScreen: {
+    type: String,
+    required: true,
+  },
+  navigationItems: {
+    type: Array,
+    required: true,
+  },
+})
+
+defineEmits(['navigate'])
+</script>
+
+<template>
+  <div class="page-shell">
+    <aside class="sidebar">
+      <div class="brand-block">
+        <h1 class="brand-title">Biddinggo</h1>
+        <p class="brand-subtitle">BIDDINGMATE</p>
+      </div>
+
+      <nav class="navigation" aria-label="메인 메뉴">
+        <button
+          v-for="item in navigationItems"
+          :key="item.label"
+          type="button"
+          class="nav-item"
+          :class="{ 'is-active': currentScreen === item.key }"
+          @click="$emit('navigate', item.key)"
+        >
+          <img :src="item.icon" :alt="item.label" class="nav-icon" />
+          <span>{{ item.label }}</span>
+        </button>
+      </nav>
+    </aside>
+
+    <div class="main-area">
+      <header class="topbar">
+        <div class="search-box">
+          <img :src="assets.searchIcon" alt="" class="search-icon" />
+          <span>어떤 경매를 찾으시나요?</span>
+        </div>
+
+        <div class="top-links">
+          <button type="button">마이페이지</button>
+          <button type="button">알림</button>
+          <button type="button">로그인/회원가입</button>
+        </div>
+      </header>
+
+      <main class="content">
+        <slot />
+      </main>
+    </div>
+  </div>
+</template>

--- a/src/components/AuctionCard.vue
+++ b/src/components/AuctionCard.vue
@@ -1,0 +1,74 @@
+<script setup>
+const props = defineProps({
+  clockIcon: {
+    type: String,
+    default: '',
+  },
+  heartIcon: {
+    type: String,
+    required: true,
+  },
+  imageSrc: {
+    type: String,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+  priceLabel: {
+    type: String,
+    default: '현재 입찰가',
+  },
+  showClock: {
+    type: Boolean,
+    default: true,
+  },
+  showLiveTag: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+const emit = defineEmits(['select'])
+
+function handleSelect() {
+  emit('select', props.item)
+}
+</script>
+
+<template>
+  <article
+    class="item-card"
+    :class="{ 'is-highlight': item.highlight }"
+    @click="handleSelect"
+  >
+    <div class="item-image-wrap">
+      <span v-if="showLiveTag && item.highlight" class="live-tag">TIME DEAL</span>
+      <img :src="imageSrc" :alt="item.title" class="item-image" />
+
+      <button type="button" class="wish-button" aria-label="관심상품 추가" @click.stop>
+        <img :src="heartIcon" alt="" />
+      </button>
+    </div>
+
+    <div class="item-body">
+      <p class="item-title">{{ item.title }}</p>
+
+      <div class="price-block">
+        <span>{{ priceLabel }}</span>
+        <strong>{{ item.price }}</strong>
+      </div>
+
+      <div class="item-meta">
+        <span>{{ showClock ? item.bids : '검수 상태' }}</span>
+        <span class="divider"></span>
+        <span v-if="showClock" class="time-meta">
+          <img :src="clockIcon" alt="" />
+          {{ item.time }}
+        </span>
+        <span v-else>{{ item.time }}</span>
+      </div>
+    </div>
+  </article>
+</template>

--- a/src/components/AuctionDetailScreen.vue
+++ b/src/components/AuctionDetailScreen.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 const props = defineProps({
   assets: {
@@ -22,18 +22,87 @@ const reportTypes = [
   '도난물 의심',
   '기타',
 ]
+const bidHistoryRows = [
+  '1번 입찰자',
+  '2번 입찰자',
+  '3번 입찰자',
+  '4번 입찰자',
+  '5번 입찰자',
+  '6번 입찰자',
+  '1번 입찰자',
+  '2번 입찰자',
+  '2번 입찰자',
+  '2번 입찰자',
+  '7번 입찰자',
+  '8번 입찰자',
+  '1번 입찰자',
+  '10번 입찰자',
+].map((bidder) => ({
+  bidder,
+  amount: '***원',
+  date: '20xx/xx/xx xx:xx:xx.xx',
+}))
 
+function parseAmount(value) {
+  return Number(String(value).replace(/[^\d]/g, '')) || 0
+}
+
+function formatAmount(value) {
+  return new Intl.NumberFormat('ko-KR').format(value)
+}
+
+const minimumBidAmount = computed(() => parseAmount(props.item.price) + parseAmount(props.item.bidUnit))
+const buyNowAmount = computed(() => parseAmount(props.item.buyNowPrice))
+
+const isBidModalOpen = ref(false)
+const isBidHistoryDrawerOpen = ref(false)
 const isReportModalOpen = ref(false)
 const reportForm = ref({
   type: '기타',
   detail: '',
 })
+const bidAmount = ref('')
 const isInquiryModalOpen = ref(false)
 const inquiryForm = ref({
   isPrivate: true,
   title: '',
   content: '',
 })
+
+function syncBidAmount(value = minimumBidAmount.value) {
+  bidAmount.value = formatAmount(value)
+}
+
+function openBidModal() {
+  isBidHistoryDrawerOpen.value = false
+  syncBidAmount()
+  isBidModalOpen.value = true
+}
+
+function closeBidModal() {
+  isBidModalOpen.value = false
+}
+
+function stepBid(direction) {
+  const nextAmount = parseAmount(bidAmount.value || minimumBidAmount.value) + parseAmount(props.item.bidUnit) * direction
+  syncBidAmount(Math.max(minimumBidAmount.value, nextAmount))
+}
+
+function submitBid() {
+  isBidModalOpen.value = false
+}
+
+function buyNow() {
+  isBidModalOpen.value = false
+}
+
+function openBidHistoryDrawer() {
+  isBidHistoryDrawerOpen.value = true
+}
+
+function closeBidHistoryDrawer() {
+  isBidHistoryDrawerOpen.value = false
+}
 
 function openReportModal() {
   isReportModalOpen.value = true
@@ -164,7 +233,7 @@ function submitInquiry() {
               <span>입찰 금액</span>
               <input type="text" :value="item.price" />
             </label>
-            <button type="button" class="detail-bid-button">지금 입찰하기</button>
+            <button type="button" class="detail-bid-button" @click="openBidModal">지금 입찰하기</button>
           </div>
 
           <div class="detail-stats">
@@ -176,7 +245,10 @@ function submitInquiry() {
         </div>
 
         <div class="history-panel">
-          <div class="history-heading">입찰 기록</div>
+          <div class="history-header">
+            <div class="history-heading">입찰 기록</div>
+            <button type="button" class="history-view-all" @click="openBidHistoryDrawer">View All</button>
+          </div>
           <div class="history-list">
             <div v-for="(row, index) in item.history" :key="`${row.bidder}-${index}`" class="history-row">
               <span>{{ row.bidder }}</span>
@@ -185,9 +257,105 @@ function submitInquiry() {
             </div>
           </div>
         </div>
-
-        <button type="button" class="back-to-list" @click="$emit('back')">목록으로</button>
       </div>
+    </div>
+
+    <div
+      v-if="isBidHistoryDrawerOpen"
+      class="detail-history-drawer-overlay"
+      @click.self="closeBidHistoryDrawer"
+    >
+      <aside class="detail-history-drawer">
+        <div class="detail-history-drawer-top">
+          <button type="button" class="detail-history-drawer-close" @click="closeBidHistoryDrawer">
+            ×
+          </button>
+        </div>
+
+        <div class="detail-history-drawer-summary">
+          <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
+          <div class="detail-inquiry-summary-copy">
+            <strong>{{ item.title }}</strong>
+            <span>현재 입찰가</span>
+            <em>{{ item.price }}원</em>
+          </div>
+        </div>
+
+        <div class="detail-history-table">
+          <div class="detail-history-table-head">
+            <span>입찰자</span>
+            <span>입찰액</span>
+            <span>입찰 일시</span>
+          </div>
+
+          <div class="detail-history-table-body">
+            <div
+              v-for="(row, index) in bidHistoryRows"
+              :key="`${row.bidder}-${index}`"
+              class="detail-history-table-row"
+            >
+              <span>{{ row.bidder }}</span>
+              <strong>{{ row.amount }}</strong>
+              <span>{{ row.date }}</span>
+            </div>
+          </div>
+        </div>
+
+        <button type="button" class="detail-history-action" @click="openBidModal">
+          입찰하기
+        </button>
+      </aside>
+    </div>
+
+    <div v-if="isBidModalOpen" class="detail-inquiry-overlay" @click.self="closeBidModal">
+      <section class="detail-bid-modal">
+        <div class="detail-inquiry-header">
+          <h3>입찰하기</h3>
+          <button type="button" class="detail-inquiry-close" @click="closeBidModal">×</button>
+        </div>
+
+        <div class="detail-inquiry-summary">
+          <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
+          <div class="detail-inquiry-summary-copy">
+            <strong>{{ item.title }}</strong>
+            <span>현재 입찰가</span>
+            <em>{{ item.price }}원</em>
+          </div>
+        </div>
+
+        <div class="detail-bid-modal-body">
+          <div class="detail-bid-meta-row">
+            <span>입찰 단위</span>
+            <strong>{{ item.bidUnit }}원</strong>
+          </div>
+
+          <label class="detail-bid-modal-label">입찰 금액</label>
+
+          <label class="detail-bid-input-row">
+            <input
+              v-model="bidAmount"
+              type="text"
+              :placeholder="`최소 ${formatAmount(minimumBidAmount)}`"
+            />
+            <span>원</span>
+          </label>
+
+          <div class="detail-bid-quick-actions">
+            <button type="button" class="detail-bid-quick-chip" @click="stepBid(-1)">- {{ item.bidUnit }}</button>
+            <button type="button" class="detail-bid-quick-chip" @click="stepBid(1)">+ {{ item.bidUnit }}</button>
+          </div>
+        </div>
+
+        <div class="detail-bid-modal-actions">
+          <button type="button" class="detail-buy-now-button" @click="buyNow">
+            <span>{{ formatAmount(buyNowAmount) }}원 으로</span>
+            <strong>즉시 구매</strong>
+          </button>
+          <button type="button" class="detail-bid-submit-button" @click="submitBid">
+            입찰하기
+          </button>
+        </div>
+      </section>
     </div>
 
     <div v-if="isReportModalOpen" class="detail-inquiry-overlay" @click.self="closeReportModal">

--- a/src/components/AuctionDetailScreen.vue
+++ b/src/components/AuctionDetailScreen.vue
@@ -42,6 +42,34 @@ const bidHistoryRows = [
   amount: '***원',
   date: '20xx/xx/xx xx:xx:xx.xx',
 }))
+const sellerProfile = {
+  avatar: 'https://www.figma.com/api/mcp/asset/1a84177d-d7c8-4353-8a50-20c14d87fbe5',
+  badge: 'https://www.figma.com/api/mcp/asset/81111f1e-47ca-4819-bcc5-08161ec6a90c',
+  rating: '4.8',
+  reviewCount: 100,
+  joinedAt: '2022. 03. 15',
+  stats: [
+    { label: '총 판매 건수', value: '1,000' },
+    { label: '판매 취소', value: '3' },
+    { label: '반품', value: '0' },
+    { label: '응답률', value: '98%' },
+  ],
+  reviews: [
+    {
+      author: 'Kim_D***',
+      date: '2023. 11. 24',
+      rating: 5,
+      content:
+        '포장이 정말 꼼꼼하게 잘 되어 왔습니다. 배송도 생각보다 훨씬 빠르고 물건 상태도 설명하신 것보다 더 좋네요. 믿고 거래할 수 있는 판매자입니다.',
+    },
+    {
+      author: 'Lee_H***',
+      date: '2023. 11. 20',
+      rating: 4,
+      content: '답변이 아주 빠르셔서 궁금한 점을 바로 해결할 수 있었습니다. 좋은 경매 감사합니다!',
+    },
+  ],
+}
 
 function parseAmount(value) {
   return Number(String(value).replace(/[^\d]/g, '')) || 0
@@ -54,6 +82,7 @@ function formatAmount(value) {
 const minimumBidAmount = computed(() => parseAmount(props.item.price) + parseAmount(props.item.bidUnit))
 const buyNowAmount = computed(() => parseAmount(props.item.buyNowPrice))
 
+const isSellerModalOpen = ref(false)
 const isBidModalOpen = ref(false)
 const isBidHistoryDrawerOpen = ref(false)
 const isReportModalOpen = ref(false)
@@ -68,6 +97,14 @@ const inquiryForm = ref({
   title: '',
   content: '',
 })
+
+function openSellerModal() {
+  isSellerModalOpen.value = true
+}
+
+function closeSellerModal() {
+  isSellerModalOpen.value = false
+}
 
 function syncBidAmount(value = minimumBidAmount.value) {
   bidAmount.value = formatAmount(value)
@@ -158,7 +195,9 @@ function submitInquiry() {
           <div class="seller-meta">
             <div class="seller-avatar"></div>
             <div class="seller-info">
-              <span class="seller-name">{{ item.seller }}</span>
+              <button type="button" class="seller-name-button" @click="openSellerModal">
+                {{ item.seller }}
+              </button>
               <span class="seller-grade">{{ item.sellerGrade }}</span>
             </div>
           </div>
@@ -258,6 +297,80 @@ function submitInquiry() {
           </div>
         </div>
       </div>
+    </div>
+
+    <div v-if="isSellerModalOpen" class="detail-inquiry-overlay" @click.self="closeSellerModal">
+      <section class="detail-seller-modal">
+        <div class="detail-seller-modal-header">
+          <button type="button" class="detail-inquiry-close" @click="closeSellerModal">×</button>
+        </div>
+
+        <div class="detail-seller-profile">
+          <img :src="sellerProfile.avatar" :alt="item.seller" class="detail-seller-avatar" />
+          <div class="detail-seller-copy">
+            <div class="detail-seller-name-row">
+              <img :src="sellerProfile.badge" alt="" class="detail-seller-badge" />
+              <strong>{{ item.seller }}</strong>
+            </div>
+
+            <div class="detail-seller-meta-row">
+              <div class="detail-seller-rating">
+                <span
+                  v-for="starIndex in 5"
+                  :key="`seller-star-${starIndex}`"
+                  class="detail-seller-star"
+                >
+                  {{ starIndex <= Math.round(Number(sellerProfile.rating)) ? '★' : '☆' }}
+                </span>
+                <span class="detail-seller-rating-value">{{ sellerProfile.rating }}</span>
+                <span class="detail-seller-review-count">(리뷰 {{ sellerProfile.reviewCount }})</span>
+              </div>
+
+              <div class="detail-seller-joined">가입일: {{ sellerProfile.joinedAt }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="detail-seller-stats">
+          <article
+            v-for="stat in sellerProfile.stats"
+            :key="stat.label"
+            class="detail-seller-stat-card"
+          >
+            <span>{{ stat.label }}</span>
+            <strong>{{ stat.value }}</strong>
+          </article>
+        </div>
+
+        <div class="detail-seller-reviews">
+          <h3>구매자 리뷰 ({{ sellerProfile.reviewCount }})</h3>
+
+          <article
+            v-for="review in sellerProfile.reviews"
+            :key="`${review.author}-${review.date}`"
+            class="detail-seller-review"
+          >
+            <div class="detail-seller-review-top">
+              <div>
+                <strong>{{ review.author }}</strong>
+                <span>{{ review.date }}</span>
+              </div>
+              <div class="detail-seller-review-stars">
+                <span
+                  v-for="starIndex in 5"
+                  :key="`${review.author}-star-${starIndex}`"
+                  class="detail-seller-star"
+                >
+                  {{ starIndex <= review.rating ? '★' : '☆' }}
+                </span>
+              </div>
+            </div>
+
+            <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-seller-review-image" />
+            <p>{{ review.content }}</p>
+          </article>
+        </div>
+      </section>
     </div>
 
     <div

--- a/src/components/AuctionDetailScreen.vue
+++ b/src/components/AuctionDetailScreen.vue
@@ -1,0 +1,146 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['back'])
+</script>
+
+<template>
+  <section class="detail-screen">
+    <div class="detail-title-row">
+      <div class="detail-breadcrumb">{{ item.brand }} |</div>
+      <div class="detail-chip">
+        <span>span</span>
+      </div>
+    </div>
+
+    <div class="detail-grid">
+      <div class="detail-left">
+        <div class="detail-image-card">
+          <img :src="assets.listWatchImage" :alt="item.title" class="detail-image" />
+          <button type="button" class="gallery-arrow gallery-arrow-left">‹</button>
+          <button type="button" class="gallery-arrow gallery-arrow-right">›</button>
+        </div>
+
+        <div class="inspection-banner">
+          <div class="inspection-icon">✓</div>
+          <div>
+            <strong>{{ item.inspectionLabel }}</strong>
+            <p>{{ item.inspectionDescription }}</p>
+          </div>
+        </div>
+
+        <div class="seller-card">
+          <div class="seller-meta">
+            <div class="seller-avatar"></div>
+            <div class="seller-info">
+              <span class="seller-name">{{ item.seller }}</span>
+              <span class="seller-grade">{{ item.sellerGrade }}</span>
+            </div>
+          </div>
+          <button type="button" class="seller-button">문의 하기</button>
+        </div>
+
+        <div class="detail-description-card">
+          <p>{{ item.description }}</p>
+        </div>
+
+        <div class="inquiry-section">
+          <div class="inquiry-heading">상품 문의 (2)</div>
+          <div class="inquiry-list">
+            <article
+              v-for="(inquiry, index) in item.inquiries"
+              :key="`${inquiry.title}-${index}`"
+              class="inquiry-item"
+              :class="{ 'is-expanded': index === 0 }"
+            >
+              <div class="inquiry-summary">
+                <div class="inquiry-summary-left">
+                  <span class="status-badge" :class="{ 'is-pending': inquiry.status === '답변 대기' }">
+                    {{ inquiry.status }}
+                  </span>
+                  <div class="inquiry-text">
+                    <strong>{{ inquiry.title }}</strong>
+                    <span>{{ inquiry.meta }}</span>
+                  </div>
+                </div>
+                <span class="inquiry-toggle">{{ index === 0 ? '⌃' : '⌄' }}</span>
+              </div>
+
+              <div v-if="index === 0" class="inquiry-detail">
+                <div class="question-box">
+                  {{ inquiry.question }}
+                </div>
+                <div class="answer-box">
+                  <div class="answer-label">판매자 답변</div>
+                  <p>{{ inquiry.answer }}</p>
+                </div>
+              </div>
+            </article>
+          </div>
+        </div>
+      </div>
+
+      <div class="detail-right">
+        <div class="price-panel">
+          <div class="price-top-line">
+            <div class="price-tags">
+              <span class="price-tag is-danger">TIME DEAL</span>
+              <span class="price-tag is-light">검수 완료</span>
+            </div>
+            <button type="button" class="detail-heart-button">
+              <img :src="assets.heartIcon" alt="" />
+            </button>
+          </div>
+
+          <p class="detail-brand-line">{{ item.brand }} |</p>
+          <h2 class="detail-product-title">{{ item.title }}</h2>
+
+          <div class="detail-price-block">
+            <span>현재 입찰가</span>
+            <strong>{{ item.price }}</strong>
+          </div>
+
+          <p class="detail-price-meta">{{ item.bids }} | 시작가 {{ item.price }}</p>
+          <p class="detail-time-left">{{ item.time }}</p>
+
+          <div class="detail-bid-box">
+            <label class="detail-bid-field">
+              <span>입찰 금액</span>
+              <input type="text" :value="item.price" />
+            </label>
+            <button type="button" class="detail-bid-button">지금 입찰하기</button>
+          </div>
+
+          <div class="detail-stats">
+            <div><span>입찰 단위</span><strong>{{ item.bidUnit }}</strong></div>
+            <div><span>즉시 구매가</span><strong>{{ item.buyNowPrice }}</strong></div>
+            <div><span>시작일</span><strong>{{ item.startDate }}</strong></div>
+            <div><span>종료일</span><strong>{{ item.endDate }}</strong></div>
+          </div>
+        </div>
+
+        <div class="history-panel">
+          <div class="history-heading">입찰 기록</div>
+          <div class="history-list">
+            <div v-for="(row, index) in item.history" :key="`${row.bidder}-${index}`" class="history-row">
+              <span>{{ row.bidder }}</span>
+              <strong>{{ row.amount }}</strong>
+              <span>{{ row.date }}</span>
+            </div>
+          </div>
+        </div>
+
+        <button type="button" class="back-to-list" @click="$emit('back')">목록으로</button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/AuctionDetailScreen.vue
+++ b/src/components/AuctionDetailScreen.vue
@@ -1,5 +1,16 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
+import BidHistoryDrawer from './auction-detail/BidHistoryDrawer.vue'
+import BidModal from './auction-detail/BidModal.vue'
+import DetailMediaSection from './auction-detail/DetailMediaSection.vue'
+import HistoryPanel from './auction-detail/HistoryPanel.vue'
+import InquiryModal from './auction-detail/InquiryModal.vue'
+import InquirySection from './auction-detail/InquirySection.vue'
+import PricePanel from './auction-detail/PricePanel.vue'
+import ReportModal from './auction-detail/ReportModal.vue'
+import SellerCardSection from './auction-detail/SellerCardSection.vue'
+import SellerProfileModal from './auction-detail/SellerProfileModal.vue'
+import { useAuctionDetailState } from '../composables/useAuctionDetailState'
 
 const props = defineProps({
   assets: {
@@ -14,156 +25,38 @@ const props = defineProps({
 
 defineEmits(['back'])
 
-const reportTypes = [
-  '위조품 / 가짜 상품',
-  '허위 / 과장 정보',
-  '부적절한 콘텐츠',
-  '중복 등록',
-  '도난물 의심',
-  '기타',
-]
-const bidHistoryRows = [
-  '1번 입찰자',
-  '2번 입찰자',
-  '3번 입찰자',
-  '4번 입찰자',
-  '5번 입찰자',
-  '6번 입찰자',
-  '1번 입찰자',
-  '2번 입찰자',
-  '2번 입찰자',
-  '2번 입찰자',
-  '7번 입찰자',
-  '8번 입찰자',
-  '1번 입찰자',
-  '10번 입찰자',
-].map((bidder) => ({
-  bidder,
-  amount: '***원',
-  date: '20xx/xx/xx xx:xx:xx.xx',
-}))
-const sellerProfile = {
-  avatar: 'https://www.figma.com/api/mcp/asset/1a84177d-d7c8-4353-8a50-20c14d87fbe5',
-  badge: 'https://www.figma.com/api/mcp/asset/81111f1e-47ca-4819-bcc5-08161ec6a90c',
-  rating: '4.8',
-  reviewCount: 100,
-  joinedAt: '2022. 03. 15',
-  stats: [
-    { label: '총 판매 건수', value: '1,000' },
-    { label: '판매 취소', value: '3' },
-    { label: '반품', value: '0' },
-    { label: '응답률', value: '98%' },
-  ],
-  reviews: [
-    {
-      author: 'Kim_D***',
-      date: '2023. 11. 24',
-      rating: 5,
-      content:
-        '포장이 정말 꼼꼼하게 잘 되어 왔습니다. 배송도 생각보다 훨씬 빠르고 물건 상태도 설명하신 것보다 더 좋네요. 믿고 거래할 수 있는 판매자입니다.',
-    },
-    {
-      author: 'Lee_H***',
-      date: '2023. 11. 20',
-      rating: 4,
-      content: '답변이 아주 빠르셔서 궁금한 점을 바로 해결할 수 있었습니다. 좋은 경매 감사합니다!',
-    },
-  ],
-}
-
-function parseAmount(value) {
-  return Number(String(value).replace(/[^\d]/g, '')) || 0
-}
-
-function formatAmount(value) {
-  return new Intl.NumberFormat('ko-KR').format(value)
-}
-
-const minimumBidAmount = computed(() => parseAmount(props.item.price) + parseAmount(props.item.bidUnit))
-const buyNowAmount = computed(() => parseAmount(props.item.buyNowPrice))
-
-const isSellerModalOpen = ref(false)
-const isBidModalOpen = ref(false)
-const isBidHistoryDrawerOpen = ref(false)
-const isReportModalOpen = ref(false)
-const reportForm = ref({
-  type: '기타',
-  detail: '',
-})
-const bidAmount = ref('')
-const isInquiryModalOpen = ref(false)
-const inquiryForm = ref({
-  isPrivate: true,
-  title: '',
-  content: '',
-})
-
-function openSellerModal() {
-  isSellerModalOpen.value = true
-}
-
-function closeSellerModal() {
-  isSellerModalOpen.value = false
-}
-
-function syncBidAmount(value = minimumBidAmount.value) {
-  bidAmount.value = formatAmount(value)
-}
-
-function openBidModal() {
-  isBidHistoryDrawerOpen.value = false
-  syncBidAmount()
-  isBidModalOpen.value = true
-}
-
-function closeBidModal() {
-  isBidModalOpen.value = false
-}
-
-function stepBid(direction) {
-  const nextAmount = parseAmount(bidAmount.value || minimumBidAmount.value) + parseAmount(props.item.bidUnit) * direction
-  syncBidAmount(Math.max(minimumBidAmount.value, nextAmount))
-}
-
-function submitBid() {
-  isBidModalOpen.value = false
-}
-
-function buyNow() {
-  isBidModalOpen.value = false
-}
-
-function openBidHistoryDrawer() {
-  isBidHistoryDrawerOpen.value = true
-}
-
-function closeBidHistoryDrawer() {
-  isBidHistoryDrawerOpen.value = false
-}
-
-function openReportModal() {
-  isReportModalOpen.value = true
-}
-
-function closeReportModal() {
-  isReportModalOpen.value = false
-}
-
-function submitReport() {
-  isReportModalOpen.value = false
-}
-
-function openInquiryModal() {
-  isInquiryModalOpen.value = true
-}
-
-function closeInquiryModal() {
-  isInquiryModalOpen.value = false
-}
-
-function submitInquiry() {
-  isInquiryModalOpen.value = false
-}
+const itemRef = computed(() => props.item)
+const {
+  bidAmount,
+  bidHistoryRows,
+  buyNow,
+  buyNowAmount,
+  closeBidHistoryDrawer,
+  closeBidModal,
+  closeInquiryModal,
+  closeReportModal,
+  closeSellerModal,
+  formatAmount,
+  inquiryForm,
+  isBidHistoryDrawerOpen,
+  isBidModalOpen,
+  isInquiryModalOpen,
+  isReportModalOpen,
+  isSellerModalOpen,
+  minimumBidAmount: minimumBidAmountFromState,
+  openBidHistoryDrawer,
+  openBidModal,
+  openInquiryModal,
+  openReportModal,
+  openSellerModal,
+  reportForm,
+  reportTypes,
+  sellerProfile,
+  stepBid,
+  submitBid,
+  submitInquiry,
+  submitReport,
+} = useAuctionDetailState(itemRef)
 </script>
 
 <template>
@@ -177,394 +70,69 @@ function submitInquiry() {
 
     <div class="detail-grid">
       <div class="detail-left">
-        <div class="detail-image-card">
-          <img :src="assets.listWatchImage" :alt="item.title" class="detail-image" />
-          <button type="button" class="gallery-arrow gallery-arrow-left">‹</button>
-          <button type="button" class="gallery-arrow gallery-arrow-right">›</button>
-        </div>
-
-        <div class="inspection-banner">
-          <div class="inspection-icon">✓</div>
-          <div>
-            <strong>{{ item.inspectionLabel }}</strong>
-            <p>{{ item.inspectionDescription }}</p>
-          </div>
-        </div>
-
-        <div class="seller-card">
-          <div class="seller-meta">
-            <div class="seller-avatar"></div>
-            <div class="seller-info">
-              <button type="button" class="seller-name-button" @click="openSellerModal">
-                {{ item.seller }}
-              </button>
-              <span class="seller-grade">{{ item.sellerGrade }}</span>
-            </div>
-          </div>
-          <button type="button" class="seller-button" @click="openInquiryModal">문의 하기</button>
-        </div>
-
+        <DetailMediaSection :assets="assets" :item="item" />
+        <SellerCardSection :item="item" @open-inquiry="openInquiryModal" @open-seller="openSellerModal" />
         <div class="detail-description-card">
           <p>{{ item.description }}</p>
         </div>
-
-        <div class="inquiry-section">
-          <div class="inquiry-heading">상품 문의 (2)</div>
-          <div class="inquiry-list">
-            <article
-              v-for="(inquiry, index) in item.inquiries"
-              :key="`${inquiry.title}-${index}`"
-              class="inquiry-item"
-              :class="{ 'is-expanded': index === 0 }"
-            >
-              <div class="inquiry-summary">
-                <div class="inquiry-summary-left">
-                  <span class="status-badge" :class="{ 'is-pending': inquiry.status === '답변 대기' }">
-                    {{ inquiry.status }}
-                  </span>
-                  <div class="inquiry-text">
-                    <strong>{{ inquiry.title }}</strong>
-                    <span>{{ inquiry.meta }}</span>
-                  </div>
-                </div>
-                <span class="inquiry-toggle">{{ index === 0 ? '⌃' : '⌄' }}</span>
-              </div>
-
-              <div v-if="index === 0" class="inquiry-detail">
-                <div class="question-box">
-                  {{ inquiry.question }}
-                </div>
-                <div class="answer-box">
-                  <div class="answer-label">판매자 답변</div>
-                  <p>{{ inquiry.answer }}</p>
-                </div>
-              </div>
-            </article>
-          </div>
-        </div>
+        <InquirySection :item="item" />
       </div>
 
       <div class="detail-right">
-        <div class="price-panel">
-          <div class="price-top-line">
-            <div class="price-tags">
-              <span class="price-tag is-danger">TIME DEAL</span>
-              <span class="price-tag is-light">검수 완료</span>
-            </div>
-            <button type="button" class="detail-heart-button">
-              <img :src="assets.heartIcon" alt="" />
-            </button>
-          </div>
-
-          <p class="detail-brand-line">{{ item.brand }} |</p>
-          <h2 class="detail-product-title">{{ item.title }}</h2>
-
-          <div class="detail-price-block">
-            <span>현재 입찰가</span>
-            <strong>{{ item.price }}</strong>
-          </div>
-
-          <p class="detail-price-meta">{{ item.bids }} | 시작가 {{ item.price }}</p>
-          <p class="detail-time-left">{{ item.time }}</p>
-
-          <div class="detail-bid-box">
-            <label class="detail-bid-field">
-              <span>입찰 금액</span>
-              <input type="text" :value="item.price" />
-            </label>
-            <button type="button" class="detail-bid-button" @click="openBidModal">지금 입찰하기</button>
-          </div>
-
-          <div class="detail-stats">
-            <div><span>입찰 단위</span><strong>{{ item.bidUnit }}</strong></div>
-            <div><span>즉시 구매가</span><strong>{{ item.buyNowPrice }}</strong></div>
-            <div><span>시작일</span><strong>{{ item.startDate }}</strong></div>
-            <div><span>종료일</span><strong>{{ item.endDate }}</strong></div>
-          </div>
-        </div>
-
-        <div class="history-panel">
-          <div class="history-header">
-            <div class="history-heading">입찰 기록</div>
-            <button type="button" class="history-view-all" @click="openBidHistoryDrawer">View All</button>
-          </div>
-          <div class="history-list">
-            <div v-for="(row, index) in item.history" :key="`${row.bidder}-${index}`" class="history-row">
-              <span>{{ row.bidder }}</span>
-              <strong>{{ row.amount }}</strong>
-              <span>{{ row.date }}</span>
-            </div>
-          </div>
-        </div>
+        <PricePanel :assets="assets" :item="item" @open-bid="openBidModal" />
+        <HistoryPanel :item="item" @view-all="openBidHistoryDrawer" />
       </div>
     </div>
 
-    <div v-if="isSellerModalOpen" class="detail-inquiry-overlay" @click.self="closeSellerModal">
-      <section class="detail-seller-modal">
-        <div class="detail-seller-modal-header">
-          <button type="button" class="detail-inquiry-close" @click="closeSellerModal">×</button>
-        </div>
+    <SellerProfileModal
+      v-if="isSellerModalOpen"
+      :assets="assets"
+      :item="item"
+      :seller-profile="sellerProfile"
+      @close="closeSellerModal"
+    />
 
-        <div class="detail-seller-profile">
-          <img :src="sellerProfile.avatar" :alt="item.seller" class="detail-seller-avatar" />
-          <div class="detail-seller-copy">
-            <div class="detail-seller-name-row">
-              <img :src="sellerProfile.badge" alt="" class="detail-seller-badge" />
-              <strong>{{ item.seller }}</strong>
-            </div>
-
-            <div class="detail-seller-meta-row">
-              <div class="detail-seller-rating">
-                <span
-                  v-for="starIndex in 5"
-                  :key="`seller-star-${starIndex}`"
-                  class="detail-seller-star"
-                >
-                  {{ starIndex <= Math.round(Number(sellerProfile.rating)) ? '★' : '☆' }}
-                </span>
-                <span class="detail-seller-rating-value">{{ sellerProfile.rating }}</span>
-                <span class="detail-seller-review-count">(리뷰 {{ sellerProfile.reviewCount }})</span>
-              </div>
-
-              <div class="detail-seller-joined">가입일: {{ sellerProfile.joinedAt }}</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="detail-seller-stats">
-          <article
-            v-for="stat in sellerProfile.stats"
-            :key="stat.label"
-            class="detail-seller-stat-card"
-          >
-            <span>{{ stat.label }}</span>
-            <strong>{{ stat.value }}</strong>
-          </article>
-        </div>
-
-        <div class="detail-seller-reviews">
-          <h3>구매자 리뷰 ({{ sellerProfile.reviewCount }})</h3>
-
-          <article
-            v-for="review in sellerProfile.reviews"
-            :key="`${review.author}-${review.date}`"
-            class="detail-seller-review"
-          >
-            <div class="detail-seller-review-top">
-              <div>
-                <strong>{{ review.author }}</strong>
-                <span>{{ review.date }}</span>
-              </div>
-              <div class="detail-seller-review-stars">
-                <span
-                  v-for="starIndex in 5"
-                  :key="`${review.author}-star-${starIndex}`"
-                  class="detail-seller-star"
-                >
-                  {{ starIndex <= review.rating ? '★' : '☆' }}
-                </span>
-              </div>
-            </div>
-
-            <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-seller-review-image" />
-            <p>{{ review.content }}</p>
-          </article>
-        </div>
-      </section>
-    </div>
-
-    <div
+    <BidHistoryDrawer
       v-if="isBidHistoryDrawerOpen"
-      class="detail-history-drawer-overlay"
-      @click.self="closeBidHistoryDrawer"
-    >
-      <aside class="detail-history-drawer">
-        <div class="detail-history-drawer-top">
-          <button type="button" class="detail-history-drawer-close" @click="closeBidHistoryDrawer">
-            ×
-          </button>
-        </div>
+      :assets="assets"
+      :item="item"
+      :rows="bidHistoryRows"
+      @close="closeBidHistoryDrawer"
+      @open-bid="openBidModal"
+    />
 
-        <div class="detail-history-drawer-summary">
-          <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
-          <div class="detail-inquiry-summary-copy">
-            <strong>{{ item.title }}</strong>
-            <span>현재 입찰가</span>
-            <em>{{ item.price }}원</em>
-          </div>
-        </div>
+    <BidModal
+      v-if="isBidModalOpen"
+      :assets="assets"
+      :bid-amount="bidAmount"
+      :buy-now-amount="buyNowAmount"
+      :format-amount="formatAmount"
+      :item="item"
+      :minimum-bid-amount="minimumBidAmountFromState"
+      @buy-now="buyNow"
+      @close="closeBidModal"
+      @step-bid="stepBid"
+      @submit-bid="submitBid"
+      @update:bid-amount="bidAmount = $event"
+    />
 
-        <div class="detail-history-table">
-          <div class="detail-history-table-head">
-            <span>입찰자</span>
-            <span>입찰액</span>
-            <span>입찰 일시</span>
-          </div>
+    <ReportModal
+      v-if="isReportModalOpen"
+      :assets="assets"
+      :form="reportForm"
+      :item="item"
+      :report-types="reportTypes"
+      @close="closeReportModal"
+      @submit="submitReport"
+    />
 
-          <div class="detail-history-table-body">
-            <div
-              v-for="(row, index) in bidHistoryRows"
-              :key="`${row.bidder}-${index}`"
-              class="detail-history-table-row"
-            >
-              <span>{{ row.bidder }}</span>
-              <strong>{{ row.amount }}</strong>
-              <span>{{ row.date }}</span>
-            </div>
-          </div>
-        </div>
-
-        <button type="button" class="detail-history-action" @click="openBidModal">
-          입찰하기
-        </button>
-      </aside>
-    </div>
-
-    <div v-if="isBidModalOpen" class="detail-inquiry-overlay" @click.self="closeBidModal">
-      <section class="detail-bid-modal">
-        <div class="detail-inquiry-header">
-          <h3>입찰하기</h3>
-          <button type="button" class="detail-inquiry-close" @click="closeBidModal">×</button>
-        </div>
-
-        <div class="detail-inquiry-summary">
-          <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
-          <div class="detail-inquiry-summary-copy">
-            <strong>{{ item.title }}</strong>
-            <span>현재 입찰가</span>
-            <em>{{ item.price }}원</em>
-          </div>
-        </div>
-
-        <div class="detail-bid-modal-body">
-          <div class="detail-bid-meta-row">
-            <span>입찰 단위</span>
-            <strong>{{ item.bidUnit }}원</strong>
-          </div>
-
-          <label class="detail-bid-modal-label">입찰 금액</label>
-
-          <label class="detail-bid-input-row">
-            <input
-              v-model="bidAmount"
-              type="text"
-              :placeholder="`최소 ${formatAmount(minimumBidAmount)}`"
-            />
-            <span>원</span>
-          </label>
-
-          <div class="detail-bid-quick-actions">
-            <button type="button" class="detail-bid-quick-chip" @click="stepBid(-1)">- {{ item.bidUnit }}</button>
-            <button type="button" class="detail-bid-quick-chip" @click="stepBid(1)">+ {{ item.bidUnit }}</button>
-          </div>
-        </div>
-
-        <div class="detail-bid-modal-actions">
-          <button type="button" class="detail-buy-now-button" @click="buyNow">
-            <span>{{ formatAmount(buyNowAmount) }}원 으로</span>
-            <strong>즉시 구매</strong>
-          </button>
-          <button type="button" class="detail-bid-submit-button" @click="submitBid">
-            입찰하기
-          </button>
-        </div>
-      </section>
-    </div>
-
-    <div v-if="isReportModalOpen" class="detail-inquiry-overlay" @click.self="closeReportModal">
-      <section class="detail-report-modal">
-        <div class="detail-inquiry-header">
-          <h3>신고하기</h3>
-          <button type="button" class="detail-inquiry-close" @click="closeReportModal">×</button>
-        </div>
-
-        <div class="detail-inquiry-summary">
-          <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
-          <div class="detail-inquiry-summary-copy">
-            <strong>{{ item.title }}</strong>
-            <span>현재 입찰가</span>
-            <em>{{ item.price }}원</em>
-          </div>
-        </div>
-
-        <div class="detail-report-fields">
-          <div class="detail-report-field">
-            <span>신고 유형 <em>*</em></span>
-            <div class="detail-report-options">
-              <button
-                v-for="type in reportTypes"
-                :key="type"
-                type="button"
-                class="detail-report-option"
-                :class="{ 'is-selected': reportForm.type === type }"
-                @click="reportForm.type = type"
-              >
-                <span class="detail-report-radio" />
-                <span>{{ type }}</span>
-              </button>
-            </div>
-          </div>
-
-          <label class="detail-report-field">
-            <span>신고 내용 <em>*</em></span>
-            <textarea
-              v-model="reportForm.detail"
-              class="detail-report-textarea"
-              placeholder="신고 사유에 대한 구체적인 내용을 작성해주세요."
-            />
-          </label>
-        </div>
-
-        <button type="button" class="detail-report-submit" @click="submitReport">
-          신고하기
-        </button>
-      </section>
-    </div>
-
-    <div v-if="isInquiryModalOpen" class="detail-inquiry-overlay" @click.self="closeInquiryModal">
-      <section class="detail-inquiry-modal">
-        <div class="detail-inquiry-header">
-          <h3>문의하기</h3>
-          <button type="button" class="detail-inquiry-close" @click="closeInquiryModal">×</button>
-        </div>
-
-        <div class="detail-inquiry-summary">
-          <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
-          <div class="detail-inquiry-summary-copy">
-            <strong>{{ item.title }}</strong>
-            <span>현재 입찰가</span>
-            <em>{{ item.price }}원</em>
-          </div>
-        </div>
-
-        <label class="detail-inquiry-secret">
-          <input v-model="inquiryForm.isPrivate" type="checkbox" />
-          <span>비밀글</span>
-        </label>
-
-        <div class="detail-inquiry-fields">
-          <label class="detail-inquiry-field">
-            <span>문의 제목 <em>*</em></span>
-            <input
-              v-model="inquiryForm.title"
-              type="text"
-              placeholder="제목을 입력해 주세요."
-            />
-          </label>
-
-          <label class="detail-inquiry-field">
-            <span>문의 내용 <em>*</em></span>
-            <textarea
-              v-model="inquiryForm.content"
-              placeholder="문의 내용을 상세히 작성해주세요."
-            />
-          </label>
-        </div>
-
-        <button type="button" class="detail-inquiry-submit" @click="submitInquiry">
-          문의하기
-        </button>
-      </section>
-    </div>
+    <InquiryModal
+      v-if="isInquiryModalOpen"
+      :assets="assets"
+      :form="inquiryForm"
+      :item="item"
+      @close="closeInquiryModal"
+      @submit="submitInquiry"
+    />
   </section>
 </template>

--- a/src/components/AuctionDetailScreen.vue
+++ b/src/components/AuctionDetailScreen.vue
@@ -1,5 +1,7 @@
 <script setup>
-defineProps({
+import { ref } from 'vue'
+
+const props = defineProps({
   assets: {
     type: Object,
     required: true,
@@ -11,15 +13,60 @@ defineProps({
 })
 
 defineEmits(['back'])
+
+const reportTypes = [
+  '위조품 / 가짜 상품',
+  '허위 / 과장 정보',
+  '부적절한 콘텐츠',
+  '중복 등록',
+  '도난물 의심',
+  '기타',
+]
+
+const isReportModalOpen = ref(false)
+const reportForm = ref({
+  type: '기타',
+  detail: '',
+})
+const isInquiryModalOpen = ref(false)
+const inquiryForm = ref({
+  isPrivate: true,
+  title: '',
+  content: '',
+})
+
+function openReportModal() {
+  isReportModalOpen.value = true
+}
+
+function closeReportModal() {
+  isReportModalOpen.value = false
+}
+
+function submitReport() {
+  isReportModalOpen.value = false
+}
+
+function openInquiryModal() {
+  isInquiryModalOpen.value = true
+}
+
+function closeInquiryModal() {
+  isInquiryModalOpen.value = false
+}
+
+function submitInquiry() {
+  isInquiryModalOpen.value = false
+}
 </script>
 
 <template>
   <section class="detail-screen">
     <div class="detail-title-row">
       <div class="detail-breadcrumb">{{ item.brand }} |</div>
-      <div class="detail-chip">
-        <span>span</span>
-      </div>
+      <button type="button" class="detail-chip detail-report-trigger" @click="openReportModal">
+        신고하기
+      </button>
     </div>
 
     <div class="detail-grid">
@@ -46,7 +93,7 @@ defineEmits(['back'])
               <span class="seller-grade">{{ item.sellerGrade }}</span>
             </div>
           </div>
-          <button type="button" class="seller-button">문의 하기</button>
+          <button type="button" class="seller-button" @click="openInquiryModal">문의 하기</button>
         </div>
 
         <div class="detail-description-card">
@@ -141,6 +188,102 @@ defineEmits(['back'])
 
         <button type="button" class="back-to-list" @click="$emit('back')">목록으로</button>
       </div>
+    </div>
+
+    <div v-if="isReportModalOpen" class="detail-inquiry-overlay" @click.self="closeReportModal">
+      <section class="detail-report-modal">
+        <div class="detail-inquiry-header">
+          <h3>신고하기</h3>
+          <button type="button" class="detail-inquiry-close" @click="closeReportModal">×</button>
+        </div>
+
+        <div class="detail-inquiry-summary">
+          <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
+          <div class="detail-inquiry-summary-copy">
+            <strong>{{ item.title }}</strong>
+            <span>현재 입찰가</span>
+            <em>{{ item.price }}원</em>
+          </div>
+        </div>
+
+        <div class="detail-report-fields">
+          <div class="detail-report-field">
+            <span>신고 유형 <em>*</em></span>
+            <div class="detail-report-options">
+              <button
+                v-for="type in reportTypes"
+                :key="type"
+                type="button"
+                class="detail-report-option"
+                :class="{ 'is-selected': reportForm.type === type }"
+                @click="reportForm.type = type"
+              >
+                <span class="detail-report-radio" />
+                <span>{{ type }}</span>
+              </button>
+            </div>
+          </div>
+
+          <label class="detail-report-field">
+            <span>신고 내용 <em>*</em></span>
+            <textarea
+              v-model="reportForm.detail"
+              class="detail-report-textarea"
+              placeholder="신고 사유에 대한 구체적인 내용을 작성해주세요."
+            />
+          </label>
+        </div>
+
+        <button type="button" class="detail-report-submit" @click="submitReport">
+          신고하기
+        </button>
+      </section>
+    </div>
+
+    <div v-if="isInquiryModalOpen" class="detail-inquiry-overlay" @click.self="closeInquiryModal">
+      <section class="detail-inquiry-modal">
+        <div class="detail-inquiry-header">
+          <h3>문의하기</h3>
+          <button type="button" class="detail-inquiry-close" @click="closeInquiryModal">×</button>
+        </div>
+
+        <div class="detail-inquiry-summary">
+          <img :src="props.assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
+          <div class="detail-inquiry-summary-copy">
+            <strong>{{ item.title }}</strong>
+            <span>현재 입찰가</span>
+            <em>{{ item.price }}원</em>
+          </div>
+        </div>
+
+        <label class="detail-inquiry-secret">
+          <input v-model="inquiryForm.isPrivate" type="checkbox" />
+          <span>비밀글</span>
+        </label>
+
+        <div class="detail-inquiry-fields">
+          <label class="detail-inquiry-field">
+            <span>문의 제목 <em>*</em></span>
+            <input
+              v-model="inquiryForm.title"
+              type="text"
+              placeholder="제목을 입력해 주세요."
+            />
+          </label>
+
+          <label class="detail-inquiry-field">
+            <span>문의 내용 <em>*</em></span>
+            <textarea
+              v-model="inquiryForm.content"
+              placeholder="문의 내용을 상세히 작성해주세요."
+            />
+          </label>
+        </div>
+
+        <button type="button" class="detail-inquiry-submit" @click="submitInquiry">
+          문의하기
+        </button>
+      </section>
     </div>
   </section>
 </template>

--- a/src/components/AuctionListScreen.vue
+++ b/src/components/AuctionListScreen.vue
@@ -1,0 +1,66 @@
+<script setup>
+import AuctionCard from './AuctionCard.vue'
+
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  categories: {
+    type: Array,
+    required: true,
+  },
+  items: {
+    type: Array,
+    required: true,
+  },
+})
+
+defineEmits(['openDetail'])
+</script>
+
+<template>
+  <section class="list-screen">
+    <div class="category-column">
+      <button
+        v-for="(item, index) in categories"
+        :key="`${item.label}-${index}`"
+        type="button"
+        class="category-button"
+        :class="[
+          { 'is-active': item.active },
+          item.indent === 1 ? 'is-indent-1' : '',
+          item.indent === 2 ? 'is-indent-2' : '',
+        ]"
+      >
+        {{ item.label }}
+      </button>
+    </div>
+
+    <div class="list-column">
+      <div class="list-toolbar">
+        <div class="list-search">
+          <img :src="assets.listSearchIcon" alt="" class="list-search-icon" />
+          <span>상품명, 브랜드 검색</span>
+        </div>
+
+        <button type="button" class="sort-button">
+          최신순
+          <img :src="assets.sortChevronIcon" alt="" />
+        </button>
+      </div>
+
+      <div class="list-grid">
+        <AuctionCard
+          v-for="(item, index) in items"
+          :key="`${item.title}-${index}`"
+          :clock-icon="assets.clockIcon"
+          :heart-icon="assets.heartIcon"
+          :image-src="assets.listWatchImage"
+          :item="item"
+          @select="$emit('openDetail', $event)"
+        />
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/HomeScreen.vue
+++ b/src/components/HomeScreen.vue
@@ -1,0 +1,56 @@
+<script setup>
+import AuctionCard from './AuctionCard.vue'
+
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  items: {
+    type: Array,
+    required: true,
+  },
+})
+
+defineEmits(['openDetail', 'openList'])
+</script>
+
+<template>
+  <div>
+    <section class="hero-section">
+      <img :src="assets.heroBackground" alt="" class="hero-background" />
+      <div class="hero-overlay"></div>
+
+      <div class="hero-copy">
+        <h2>
+          대한민국 경매,<br />
+          한 곳에서 확인하세요
+        </h2>
+        <p>
+          실시간으로 진행되는 프리미엄 아이템 경매. Biddinggo<br />
+          에서 가장 빠르고 안전하게 비딩을 시작하세요.
+        </p>
+        <button type="button" class="hero-button" @click="$emit('openList')">지금 둘러보기</button>
+      </div>
+    </section>
+
+    <section class="best-section">
+      <div class="section-heading">
+        <h3>Best Items</h3>
+        <p>현재 가장 인기 있는 경매</p>
+      </div>
+
+      <div class="card-grid">
+        <AuctionCard
+          v-for="(item, index) in items"
+          :key="`${item.title}-${index}`"
+          :clock-icon="assets.clockIcon"
+          :heart-icon="assets.heartIcon"
+          :image-src="assets.watchImage"
+          :item="item"
+          @select="$emit('openDetail', $event)"
+        />
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/components/InspectionScreen.vue
+++ b/src/components/InspectionScreen.vue
@@ -1,0 +1,55 @@
+<script setup>
+import AuctionCard from './AuctionCard.vue'
+
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  items: {
+    type: Array,
+    required: true,
+  },
+  summary: {
+    type: Array,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <section class="inspection-screen">
+    <div class="inspection-header">
+      <div>
+        <h2>검수 물품 리스트 조회</h2>
+        <p>검수 상태를 확인하고 등록 가능한 상품을 관리하세요.</p>
+      </div>
+      <button type="button" class="inspection-action">검수 신청하기</button>
+    </div>
+
+    <div class="inspection-summary-grid">
+      <article
+        v-for="item in summary"
+        :key="item.label"
+        class="inspection-summary-card"
+        :class="`is-${item.tone}`"
+      >
+        <span>{{ item.label }}</span>
+        <strong>{{ item.value }}</strong>
+      </article>
+    </div>
+
+    <div class="inspection-card-grid">
+      <AuctionCard
+        v-for="(item, index) in items"
+        :key="`${item.title}-${index}`"
+        :heart-icon="assets.heartIcon"
+        :image-src="assets.listWatchImage"
+        :item="item"
+        price-label="예상 시작가"
+        :show-clock="false"
+        :show-live-tag="false"
+      />
+    </div>
+  </section>
+</template>

--- a/src/components/InspectionScreen.vue
+++ b/src/components/InspectionScreen.vue
@@ -1,7 +1,9 @@
 <script setup>
-import AuctionCard from './AuctionCard.vue'
+import { computed, ref } from 'vue'
 
-defineProps({
+defineEmits(['open-register'])
+
+const props = defineProps({
   assets: {
     type: Object,
     required: true,
@@ -15,16 +17,86 @@ defineProps({
     required: true,
   },
 })
+
+const activeFilter = ref('전체')
+const selectedItem = ref(null)
+const isShippingModalOpen = ref(false)
+const shippingForm = ref({
+  company: '',
+  invoiceNumber: '',
+})
+
+const filterOptions = ['전체', '검수 대기', '검수 통과', '검수 반려']
+
+const filteredItems = computed(() => {
+  if (activeFilter.value === '전체') {
+    return props.items
+  }
+
+  return props.items.filter((item) => item.status === activeFilter.value)
+})
+
+function badgeClass(status) {
+  if (status === '검수 통과') return 'is-passed'
+  if (status === '검수 반려') return 'is-rejected'
+  if (status === '경매 진행 중') return 'is-auction'
+  return 'is-pending'
+}
+
+function summaryIcon(label) {
+  if (label === '총 검수 완료') return '✓'
+  if (label === '검수 대기') return '👜'
+  if (label === '검수 승인') return '⌛'
+  return '▣'
+}
+
+function openDetail(item) {
+  selectedItem.value = item
+}
+
+function closeDetail() {
+  selectedItem.value = null
+  isShippingModalOpen.value = false
+}
+
+function detailActionLabel(status) {
+  if (status === '검수 대기') return '배송 정보 등록'
+  if (status === '검수 통과') return '경매 등록'
+  if (status === '경매 진행 중') return '경매 상세 보기'
+  return '확인'
+}
+
+function handleDetailAction() {
+  if (!selectedItem.value) return
+
+  if (selectedItem.value.status === '검수 대기') {
+    isShippingModalOpen.value = true
+    return
+  }
+
+  closeDetail()
+}
+
+function closeShippingModal() {
+  isShippingModalOpen.value = false
+}
+
+function submitShippingInfo() {
+  isShippingModalOpen.value = false
+}
 </script>
 
 <template>
   <section class="inspection-screen">
     <div class="inspection-header">
       <div>
-        <h2>검수 물품 리스트 조회</h2>
-        <p>검수 상태를 확인하고 등록 가능한 상품을 관리하세요.</p>
+        <h2>사전 검수 상품</h2>
+        <p>검수가 완료된 상품을 확인하고 경매에 등록하세요.</p>
       </div>
-      <button type="button" class="inspection-action">검수 신청하기</button>
+      <button type="button" class="inspection-action" @click="$emit('open-register', 'inspection')">
+        <span class="inspection-action-plus">+</span>
+        검수 신청하기
+      </button>
     </div>
 
     <div class="inspection-summary-grid">
@@ -32,24 +104,163 @@ defineProps({
         v-for="item in summary"
         :key="item.label"
         class="inspection-summary-card"
-        :class="`is-${item.tone}`"
       >
-        <span>{{ item.label }}</span>
-        <strong>{{ item.value }}</strong>
+        <div class="inspection-summary-icon" :class="`is-${item.tone}`">
+          {{ summaryIcon(item.label) }}
+        </div>
+        <div class="inspection-summary-copy">
+          <span>{{ item.label }}</span>
+          <strong>{{ item.value }}</strong>
+        </div>
       </article>
     </div>
 
+    <div class="inspection-toolbar">
+      <div class="inspection-filters">
+        <button
+          v-for="filter in filterOptions"
+          :key="filter"
+          type="button"
+          class="inspection-filter"
+          :class="{ 'is-active': activeFilter === filter }"
+          @click="activeFilter = filter"
+        >
+          {{ filter }}
+        </button>
+      </div>
+
+      <div class="inspection-search">
+        <img :src="assets.listSearchIcon" alt="" class="inspection-search-icon" />
+        <span>상품명, 브랜드 검색</span>
+      </div>
+    </div>
+
     <div class="inspection-card-grid">
-      <AuctionCard
-        v-for="(item, index) in items"
+      <article
+        v-for="(item, index) in filteredItems"
         :key="`${item.title}-${index}`"
-        :heart-icon="assets.heartIcon"
-        :image-src="assets.listWatchImage"
-        :item="item"
-        price-label="예상 시작가"
-        :show-clock="false"
-        :show-live-tag="false"
-      />
+        class="inspection-product-card"
+        @click="openDetail(item)"
+      >
+        <div class="inspection-product-image-wrap">
+          <img :src="assets.listWatchImage" :alt="item.title" class="inspection-product-image" />
+          <span class="inspection-badge" :class="badgeClass(item.status)">
+            {{ item.status }}
+          </span>
+        </div>
+
+        <div class="inspection-product-body">
+          <h3>{{ item.title }}</h3>
+          <div class="inspection-product-meta">
+            <div>
+              <span>검수 등급</span>
+              <strong>{{ item.inspectionGrade }}</strong>
+            </div>
+            <span>{{ item.inspectionDate }}</span>
+          </div>
+        </div>
+      </article>
+    </div>
+
+    <div v-if="selectedItem" class="inspection-status-overlay" @click.self="closeDetail">
+      <section class="inspection-status-modal">
+        <button type="button" class="inspection-status-close" @click="closeDetail">
+          ×
+        </button>
+
+        <div class="inspection-status-grid">
+          <div class="inspection-status-image-card">
+            <img :src="assets.listWatchImage" :alt="selectedItem.title" class="inspection-status-image" />
+          </div>
+
+          <div class="inspection-status-summary">
+            <p class="inspection-status-category">럭셔리 &gt; 시계 &gt; 남성용 시계</p>
+            <span class="inspection-badge" :class="badgeClass(selectedItem.status)">
+              {{ selectedItem.status }}
+            </span>
+            <h3>{{ selectedItem.title }}</h3>
+
+            <div class="inspection-status-meta">
+              <div>
+                <span>브랜드</span>
+                <strong>{{ selectedItem.brand }}</strong>
+              </div>
+              <div>
+                <span>검수일</span>
+                <strong>{{ selectedItem.inspectionDate }}</strong>
+              </div>
+              <div>
+                <span>검수 등급</span>
+                <strong class="is-grade">{{ selectedItem.inspectionGrade }}</strong>
+              </div>
+            </div>
+          </div>
+
+          <div class="inspection-status-section">
+            <h4>상품 설명</h4>
+            <p>{{ selectedItem.description }}</p>
+          </div>
+
+          <div class="inspection-status-section">
+            <h4>배송 정보</h4>
+
+            <div v-if="selectedItem.status === '검수 대기'" class="inspection-status-alert">
+              <span class="inspection-status-alert-icon">!</span>
+              <p>배송 정보를 등록해주세요</p>
+            </div>
+
+            <template v-else>
+              <p>우체국 택배</p>
+              <p>1928391823798</p>
+            </template>
+          </div>
+        </div>
+
+        <div class="inspection-status-actions">
+          <button type="button" class="register-secondary-button" @click="closeDetail">
+            {{ selectedItem.status === '검수 대기' ? '신청 취소' : '닫기' }}
+          </button>
+          <button type="button" class="register-primary-button" @click="handleDetailAction">
+            {{ detailActionLabel(selectedItem.status) }}
+          </button>
+        </div>
+      </section>
+    </div>
+
+    <div v-if="isShippingModalOpen" class="inspection-shipping-overlay" @click.self="closeShippingModal">
+      <section class="inspection-shipping-modal">
+        <div class="inspection-shipping-header">
+          <h3>배송 정보 등록</h3>
+          <button type="button" class="inspection-shipping-close" @click="closeShippingModal">×</button>
+        </div>
+
+        <div class="inspection-shipping-form">
+          <label class="inspection-shipping-field is-small">
+            <span>택배사 <em>*</em></span>
+            <div class="register-select-wrap">
+              <select v-model="shippingForm.company">
+                <option value="" disabled>선택</option>
+                <option value="우체국 택배">우체국 택배</option>
+                <option value="CJ대한통운">CJ대한통운</option>
+                <option value="한진택배">한진택배</option>
+              </select>
+            </div>
+          </label>
+
+          <label class="inspection-shipping-field">
+            <span>송장 번호 <em>*</em></span>
+            <input
+              v-model="shippingForm.invoiceNumber"
+              type="text"
+              placeholder="송장 번호를 입력해 주세요."
+            />
+          </label>
+        </div>
+
+        <button type="button" class="inspection-shipping-submit" @click="submitShippingInfo">
+          등록하기
+        </button>
+      </section>
     </div>
   </section>
 </template>

--- a/src/components/InspectionScreen.vue
+++ b/src/components/InspectionScreen.vue
@@ -1,5 +1,11 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { toRef } from 'vue'
+import { useInspectionState } from '../composables/useInspectionState'
+import InspectionDetailModal from './inspection/InspectionDetailModal.vue'
+import InspectionProductGrid from './inspection/InspectionProductGrid.vue'
+import InspectionShippingModal from './inspection/InspectionShippingModal.vue'
+import InspectionSummaryGrid from './inspection/InspectionSummaryGrid.vue'
+import InspectionToolbar from './inspection/InspectionToolbar.vue'
 
 defineEmits(['open-register'])
 
@@ -18,72 +24,22 @@ const props = defineProps({
   },
 })
 
-const activeFilter = ref('전체')
-const selectedItem = ref(null)
-const isShippingModalOpen = ref(false)
-const shippingForm = ref({
-  company: '',
-  invoiceNumber: '',
-})
-
-const filterOptions = ['전체', '검수 대기', '검수 통과', '검수 반려']
-
-const filteredItems = computed(() => {
-  if (activeFilter.value === '전체') {
-    return props.items
-  }
-
-  return props.items.filter((item) => item.status === activeFilter.value)
-})
-
-function badgeClass(status) {
-  if (status === '검수 통과') return 'is-passed'
-  if (status === '검수 반려') return 'is-rejected'
-  if (status === '경매 진행 중') return 'is-auction'
-  return 'is-pending'
-}
-
-function summaryIcon(label) {
-  if (label === '총 검수 완료') return '✓'
-  if (label === '검수 대기') return '👜'
-  if (label === '검수 승인') return '⌛'
-  return '▣'
-}
-
-function openDetail(item) {
-  selectedItem.value = item
-}
-
-function closeDetail() {
-  selectedItem.value = null
-  isShippingModalOpen.value = false
-}
-
-function detailActionLabel(status) {
-  if (status === '검수 대기') return '배송 정보 등록'
-  if (status === '검수 통과') return '경매 등록'
-  if (status === '경매 진행 중') return '경매 상세 보기'
-  return '확인'
-}
-
-function handleDetailAction() {
-  if (!selectedItem.value) return
-
-  if (selectedItem.value.status === '검수 대기') {
-    isShippingModalOpen.value = true
-    return
-  }
-
-  closeDetail()
-}
-
-function closeShippingModal() {
-  isShippingModalOpen.value = false
-}
-
-function submitShippingInfo() {
-  isShippingModalOpen.value = false
-}
+const {
+  activeFilter,
+  badgeClass,
+  closeDetail,
+  closeShippingModal,
+  detailActionLabel,
+  filterOptions,
+  filteredItems,
+  handleDetailAction,
+  isShippingModalOpen,
+  openDetail,
+  selectedItem,
+  shippingForm,
+  submitShippingInfo,
+  summaryIcon,
+} = useInspectionState(toRef(props, 'items'))
 </script>
 
 <template>
@@ -99,168 +55,37 @@ function submitShippingInfo() {
       </button>
     </div>
 
-    <div class="inspection-summary-grid">
-      <article
-        v-for="item in summary"
-        :key="item.label"
-        class="inspection-summary-card"
-      >
-        <div class="inspection-summary-icon" :class="`is-${item.tone}`">
-          {{ summaryIcon(item.label) }}
-        </div>
-        <div class="inspection-summary-copy">
-          <span>{{ item.label }}</span>
-          <strong>{{ item.value }}</strong>
-        </div>
-      </article>
-    </div>
+    <InspectionSummaryGrid :summary="summary" :summary-icon="summaryIcon" />
 
-    <div class="inspection-toolbar">
-      <div class="inspection-filters">
-        <button
-          v-for="filter in filterOptions"
-          :key="filter"
-          type="button"
-          class="inspection-filter"
-          :class="{ 'is-active': activeFilter === filter }"
-          @click="activeFilter = filter"
-        >
-          {{ filter }}
-        </button>
-      </div>
+    <InspectionToolbar
+      :active-filter="activeFilter"
+      :assets="assets"
+      :filter-options="filterOptions"
+      @update:active-filter="activeFilter = $event"
+    />
 
-      <div class="inspection-search">
-        <img :src="assets.listSearchIcon" alt="" class="inspection-search-icon" />
-        <span>상품명, 브랜드 검색</span>
-      </div>
-    </div>
+    <InspectionProductGrid
+      :assets="assets"
+      :badge-class="badgeClass"
+      :items="filteredItems"
+      @open-detail="openDetail"
+    />
 
-    <div class="inspection-card-grid">
-      <article
-        v-for="(item, index) in filteredItems"
-        :key="`${item.title}-${index}`"
-        class="inspection-product-card"
-        @click="openDetail(item)"
-      >
-        <div class="inspection-product-image-wrap">
-          <img :src="assets.listWatchImage" :alt="item.title" class="inspection-product-image" />
-          <span class="inspection-badge" :class="badgeClass(item.status)">
-            {{ item.status }}
-          </span>
-        </div>
+    <InspectionDetailModal
+      v-if="selectedItem"
+      :assets="assets"
+      :badge-class="badgeClass"
+      :detail-action-label="detailActionLabel"
+      :item="selectedItem"
+      @close="closeDetail"
+      @handle-action="handleDetailAction"
+    />
 
-        <div class="inspection-product-body">
-          <h3>{{ item.title }}</h3>
-          <div class="inspection-product-meta">
-            <div>
-              <span>검수 등급</span>
-              <strong>{{ item.inspectionGrade }}</strong>
-            </div>
-            <span>{{ item.inspectionDate }}</span>
-          </div>
-        </div>
-      </article>
-    </div>
-
-    <div v-if="selectedItem" class="inspection-status-overlay" @click.self="closeDetail">
-      <section class="inspection-status-modal">
-        <button type="button" class="inspection-status-close" @click="closeDetail">
-          ×
-        </button>
-
-        <div class="inspection-status-grid">
-          <div class="inspection-status-image-card">
-            <img :src="assets.listWatchImage" :alt="selectedItem.title" class="inspection-status-image" />
-          </div>
-
-          <div class="inspection-status-summary">
-            <p class="inspection-status-category">럭셔리 &gt; 시계 &gt; 남성용 시계</p>
-            <span class="inspection-badge" :class="badgeClass(selectedItem.status)">
-              {{ selectedItem.status }}
-            </span>
-            <h3>{{ selectedItem.title }}</h3>
-
-            <div class="inspection-status-meta">
-              <div>
-                <span>브랜드</span>
-                <strong>{{ selectedItem.brand }}</strong>
-              </div>
-              <div>
-                <span>검수일</span>
-                <strong>{{ selectedItem.inspectionDate }}</strong>
-              </div>
-              <div>
-                <span>검수 등급</span>
-                <strong class="is-grade">{{ selectedItem.inspectionGrade }}</strong>
-              </div>
-            </div>
-          </div>
-
-          <div class="inspection-status-section">
-            <h4>상품 설명</h4>
-            <p>{{ selectedItem.description }}</p>
-          </div>
-
-          <div class="inspection-status-section">
-            <h4>배송 정보</h4>
-
-            <div v-if="selectedItem.status === '검수 대기'" class="inspection-status-alert">
-              <span class="inspection-status-alert-icon">!</span>
-              <p>배송 정보를 등록해주세요</p>
-            </div>
-
-            <template v-else>
-              <p>우체국 택배</p>
-              <p>1928391823798</p>
-            </template>
-          </div>
-        </div>
-
-        <div class="inspection-status-actions">
-          <button type="button" class="register-secondary-button" @click="closeDetail">
-            {{ selectedItem.status === '검수 대기' ? '신청 취소' : '닫기' }}
-          </button>
-          <button type="button" class="register-primary-button" @click="handleDetailAction">
-            {{ detailActionLabel(selectedItem.status) }}
-          </button>
-        </div>
-      </section>
-    </div>
-
-    <div v-if="isShippingModalOpen" class="inspection-shipping-overlay" @click.self="closeShippingModal">
-      <section class="inspection-shipping-modal">
-        <div class="inspection-shipping-header">
-          <h3>배송 정보 등록</h3>
-          <button type="button" class="inspection-shipping-close" @click="closeShippingModal">×</button>
-        </div>
-
-        <div class="inspection-shipping-form">
-          <label class="inspection-shipping-field is-small">
-            <span>택배사 <em>*</em></span>
-            <div class="register-select-wrap">
-              <select v-model="shippingForm.company">
-                <option value="" disabled>선택</option>
-                <option value="우체국 택배">우체국 택배</option>
-                <option value="CJ대한통운">CJ대한통운</option>
-                <option value="한진택배">한진택배</option>
-              </select>
-            </div>
-          </label>
-
-          <label class="inspection-shipping-field">
-            <span>송장 번호 <em>*</em></span>
-            <input
-              v-model="shippingForm.invoiceNumber"
-              type="text"
-              placeholder="송장 번호를 입력해 주세요."
-            />
-          </label>
-        </div>
-
-        <button type="button" class="inspection-shipping-submit" @click="submitShippingInfo">
-          등록하기
-        </button>
-      </section>
-    </div>
+    <InspectionShippingModal
+      v-if="isShippingModalOpen"
+      :form="shippingForm"
+      @close="closeShippingModal"
+      @submit="submitShippingInfo"
+    />
   </section>
 </template>

--- a/src/components/MyPageScreen.vue
+++ b/src/components/MyPageScreen.vue
@@ -1,4 +1,8 @@
 <script setup>
+import MyPageBidSection from './mypage/MyPageBidSection.vue'
+import MyPageProfileCard from './mypage/MyPageProfileCard.vue'
+import MyPagePurchaseSection from './mypage/MyPagePurchaseSection.vue'
+
 const props = defineProps({
   assets: {
     type: Object,
@@ -29,83 +33,8 @@ function purchaseBadgeClass(status) {
       <h2>마이페이지</h2>
     </header>
 
-    <section class="mypage-profile-card">
-      <div class="mypage-profile-row">
-        <div class="mypage-profile-user">
-          <img :src="assets.mypageAvatar" :alt="profile.seller" class="mypage-avatar" />
-          <div class="mypage-user-copy">
-            <img :src="assets.mypageBadge" alt="" class="mypage-badge" />
-            <strong>{{ profile.seller }}</strong>
-          </div>
-        </div>
-      </div>
-
-      <div class="mypage-points-block">
-        <span>보유 포인트</span>
-        <strong>{{ profile.points }}</strong>
-      </div>
-    </section>
-
-    <section class="mypage-section">
-      <div class="mypage-section-header">
-        <h3>입찰 내역</h3>
-        <button type="button">View All</button>
-      </div>
-
-      <div class="mypage-bid-list">
-        <article
-          v-for="(item, index) in bidItems"
-          :key="`${item.title}-${index}`"
-          class="mypage-bid-card"
-        >
-          <img :src="assets.mypageProductImage" :alt="item.title" class="mypage-bid-image" />
-
-          <div class="mypage-bid-content">
-            <div class="mypage-bid-copy">
-              <span class="mypage-chip is-auction">{{ item.status }}</span>
-              <h4>{{ item.title }}</h4>
-              <div class="mypage-time">
-                <img :src="assets.clockIcon" alt="" />
-                <span>{{ item.time }}</span>
-              </div>
-            </div>
-
-            <div class="mypage-bid-prices">
-              <span>현재가</span>
-              <strong>{{ item.currentPrice }}</strong>
-              <span>내 입찰가</span>
-              <strong>{{ item.myBidPrice }}</strong>
-              <span>{{ item.date }}</span>
-            </div>
-          </div>
-        </article>
-      </div>
-    </section>
-
-    <section class="mypage-section">
-      <div class="mypage-section-header">
-        <h3>진행 중 구매 현황</h3>
-        <button type="button">View All</button>
-      </div>
-
-      <div class="mypage-purchase-list">
-        <article
-          v-for="(item, index) in purchaseItems"
-          :key="`${item.title}-${index}`"
-          class="mypage-purchase-card"
-        >
-          <div class="mypage-purchase-copy">
-            <span class="mypage-chip" :class="purchaseBadgeClass(item.status)">{{ item.status }}</span>
-            <h4>{{ item.title }}</h4>
-            <p>구매자: {{ item.buyer }}</p>
-          </div>
-
-          <div class="mypage-purchase-price">
-            <strong>{{ item.price }}</strong>
-            <span>{{ item.date }}</span>
-          </div>
-        </article>
-      </div>
-    </section>
+    <MyPageProfileCard :assets="assets" :profile="profile" />
+    <MyPageBidSection :assets="assets" :items="bidItems" />
+    <MyPagePurchaseSection :items="purchaseItems" :purchase-badge-class="purchaseBadgeClass" />
   </section>
 </template>

--- a/src/components/MyPageScreen.vue
+++ b/src/components/MyPageScreen.vue
@@ -1,0 +1,111 @@
+<script setup>
+const props = defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  profile: {
+    type: Object,
+    required: true,
+  },
+  bidItems: {
+    type: Array,
+    required: true,
+  },
+  purchaseItems: {
+    type: Array,
+    required: true,
+  },
+})
+
+function purchaseBadgeClass(status) {
+  return status === '거래완료' ? 'is-complete' : 'is-waiting'
+}
+</script>
+
+<template>
+  <section class="mypage-screen">
+    <header class="mypage-header">
+      <h2>마이페이지</h2>
+    </header>
+
+    <section class="mypage-profile-card">
+      <div class="mypage-profile-row">
+        <div class="mypage-profile-user">
+          <img :src="assets.mypageAvatar" :alt="profile.seller" class="mypage-avatar" />
+          <div class="mypage-user-copy">
+            <img :src="assets.mypageBadge" alt="" class="mypage-badge" />
+            <strong>{{ profile.seller }}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div class="mypage-points-block">
+        <span>보유 포인트</span>
+        <strong>{{ profile.points }}</strong>
+      </div>
+    </section>
+
+    <section class="mypage-section">
+      <div class="mypage-section-header">
+        <h3>입찰 내역</h3>
+        <button type="button">View All</button>
+      </div>
+
+      <div class="mypage-bid-list">
+        <article
+          v-for="(item, index) in bidItems"
+          :key="`${item.title}-${index}`"
+          class="mypage-bid-card"
+        >
+          <img :src="assets.mypageProductImage" :alt="item.title" class="mypage-bid-image" />
+
+          <div class="mypage-bid-content">
+            <div class="mypage-bid-copy">
+              <span class="mypage-chip is-auction">{{ item.status }}</span>
+              <h4>{{ item.title }}</h4>
+              <div class="mypage-time">
+                <img :src="assets.clockIcon" alt="" />
+                <span>{{ item.time }}</span>
+              </div>
+            </div>
+
+            <div class="mypage-bid-prices">
+              <span>현재가</span>
+              <strong>{{ item.currentPrice }}</strong>
+              <span>내 입찰가</span>
+              <strong>{{ item.myBidPrice }}</strong>
+              <span>{{ item.date }}</span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="mypage-section">
+      <div class="mypage-section-header">
+        <h3>진행 중 구매 현황</h3>
+        <button type="button">View All</button>
+      </div>
+
+      <div class="mypage-purchase-list">
+        <article
+          v-for="(item, index) in purchaseItems"
+          :key="`${item.title}-${index}`"
+          class="mypage-purchase-card"
+        >
+          <div class="mypage-purchase-copy">
+            <span class="mypage-chip" :class="purchaseBadgeClass(item.status)">{{ item.status }}</span>
+            <h4>{{ item.title }}</h4>
+            <p>구매자: {{ item.buyer }}</p>
+          </div>
+
+          <div class="mypage-purchase-price">
+            <strong>{{ item.price }}</strong>
+            <span>{{ item.date }}</span>
+          </div>
+        </article>
+      </div>
+    </section>
+  </section>
+</template>

--- a/src/components/RegisterScreen.vue
+++ b/src/components/RegisterScreen.vue
@@ -1,6 +1,12 @@
 <script setup>
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
-import { assets, inspectionItems } from '../data/marketplaceData'
+import { toRef } from 'vue'
+import { assets } from '../data/marketplaceData'
+import { useRegisterFlow } from '../composables/useRegisterFlow'
+import AuctionSetupForm from './register/AuctionSetupForm.vue'
+import InspectionPickStep from './register/InspectionPickStep.vue'
+import RegisterMethodSelect from './register/RegisterMethodSelect.vue'
+import RegisterProductForm from './register/RegisterProductForm.vue'
+import RegisterStepper from './register/RegisterStepper.vue'
 
 const inspectionIcon = 'https://www.figma.com/api/mcp/asset/d5a99cb7-a2ca-482c-b0ca-24c4ff52d162'
 const directIcon = 'https://www.figma.com/api/mcp/asset/f2c463ba-f81c-4eba-8631-58c625f3d89b'
@@ -13,38 +19,6 @@ const props = defineProps({
     type: String,
     default: 'select',
   },
-})
-
-const allowedModes = ['select', 'inspection', 'inspection-pick', 'direct', 'direct-auction']
-const currentMode = ref(allowedModes.includes(props.initialMode) ? props.initialMode : 'select')
-const registrationType = ref(
-  props.initialMode === 'inspection' || props.initialMode === 'inspection-pick' ? 'inspection' : 'direct',
-)
-const fileInput = ref(null)
-const submitted = ref(false)
-const uploadedImages = ref([])
-const selectedBidUnit = ref('10,000')
-const selectedDuration = ref('5일')
-const selectedInspectionId = ref(0)
-const isInspectionDetailOpen = ref(false)
-
-const form = ref({
-  name: '',
-  category: '',
-  brand: '',
-  condition: '',
-  description: '',
-})
-
-const auctionForm = ref({
-  extendAuction: true,
-  timeDeal: false,
-  startPrice: '',
-  buyNowPrice: '',
-  startDate: '2024 / 03 / 27',
-  startTime: '12 : 00 : 00',
-  endDate: '2024 / 03 / 27',
-  endTime: '12 : 00 : 00',
 })
 
 const registrationMethods = [
@@ -78,203 +52,38 @@ const registrationMethods = [
   },
 ]
 
-const headerTitle = computed(() => {
-  if (currentMode.value === 'inspection') {
-    return '검수 상품 신청'
-  }
-
-  if (currentMode.value === 'inspection-pick') {
-    return '사전 검수 상품 등록'
-  }
-
-  if (currentMode.value === 'direct') {
-    return '직접 상품 등록'
-  }
-
-  if (currentMode.value === 'direct-auction') {
-    return '경매 등록'
-  }
-
-  return '경매 등록 방법 선택'
-})
-
-const headerDescription = computed(() => {
-  if (currentMode.value === 'inspection') {
-    return '검수 상품 정보를 입력해주세요.'
-  }
-
-  if (currentMode.value === 'inspection-pick') {
-    return '검수가 완료된 상품을 선택해 경매에 등록해주세요.'
-  }
-
-  if (currentMode.value === 'direct') {
-    return '경매에 등록할 상품 정보를 입력해주세요.'
-  }
-
-  if (currentMode.value === 'direct-auction') {
-    return '경매 정보를 입력해주세요.'
-  }
-
-  return '경매 등록하실 방법을 선택해주세요.'
-})
-
-const thumbnailPlaceholders = computed(() =>
-  Math.max(0, 3 - Math.max(0, uploadedImages.value.length - 1)),
-)
-
-const successMessage = computed(() =>
-  currentMode.value === 'inspection'
-    ? '더미 데이터 기준으로 검수 상품 신청이 완료되었습니다.'
-    : currentMode.value === 'direct-auction'
-      ? registrationType.value === 'inspection'
-        ? '더미 데이터 기준으로 사전 검수 상품 경매 등록이 완료되었습니다.'
-        : '더미 데이터 기준으로 경매 등록이 완료되었습니다.'
-      : '더미 데이터 기준으로 직접 상품 등록이 완료되었습니다.',
-)
-
-const showStepper = computed(() =>
-  currentMode.value === 'inspection-pick' || currentMode.value === 'direct' || currentMode.value === 'direct-auction',
-)
-
-const isAuctionStep = computed(() => currentMode.value === 'direct-auction')
-const firstStepLabel = computed(() =>
-  registrationType.value === 'inspection' ? '사전 검수 상품 등록' : '직접 상품 등록',
-)
-const bidUnitOptions = ['1,000', '5,000', '10,000', '50,000', '100,000', '직접입력']
-const durationOptions = computed(() =>
-  auctionForm.value.timeDeal
-    ? ['4시간', '8시간', '12시간', '16시간', '20시간', '24시간', '28시간', '32시간', '36시간', '40시간', '44시간', '48시간']
-    : ['3일', '4일', '5일', '6일', '7일', '8일', '9일', '10일'],
-)
-const inspectionReadyItems = computed(() =>
-  inspectionItems.filter((item) => item.status === '검수 통과'),
-)
-const selectedInspectionItem = computed(() =>
-  inspectionReadyItems.value.length
-    ? inspectionReadyItems.value[selectedInspectionId.value % inspectionReadyItems.value.length]
-    : null,
-)
-const inspectionPickItems = computed(() => {
-  if (!inspectionReadyItems.value.length) {
-    return []
-  }
-
-  return Array.from({ length: 7 }, (_, index) => ({
-    ...inspectionReadyItems.value[index % inspectionReadyItems.value.length],
-    displayId: index,
-  }))
-})
-
-function openMode(mode) {
-  registrationType.value = mode === 'inspection' || mode === 'inspection-pick' ? 'inspection' : 'direct'
-  currentMode.value = mode
-  submitted.value = false
-}
-
-function openFilePicker() {
-  fileInput.value?.click()
-}
-
-function handleFiles(event) {
-  const files = Array.from(event.target.files || [])
-  const remain = Math.max(0, 4 - uploadedImages.value.length)
-  const selected = files.slice(0, remain)
-
-  selected.forEach((file) => {
-    uploadedImages.value.push({
-      name: file.name,
-      previewUrl: URL.createObjectURL(file),
-    })
-  })
-
-  event.target.value = ''
-}
-
-function removeImage(index) {
-  const [image] = uploadedImages.value.splice(index, 1)
-
-  if (image?.previewUrl) {
-    URL.revokeObjectURL(image.previewUrl)
-  }
-}
-
-function resetForm() {
-  uploadedImages.value.forEach((image) => {
-    if (image.previewUrl) {
-      URL.revokeObjectURL(image.previewUrl)
-    }
-  })
-
-  uploadedImages.value = []
-  form.value = {
-    name: '',
-    category: '',
-    brand: '',
-    condition: '',
-    description: '',
-  }
-  submitted.value = false
-}
-
-function goBackToSelect() {
-  resetForm()
-  currentMode.value = 'select'
-}
-
-function submitForm() {
-  if (currentMode.value === 'direct' || currentMode.value === 'inspection-pick') {
-    currentMode.value = 'direct-auction'
-    submitted.value = false
-    return
-  }
-
-  submitted.value = true
-}
-
-function returnFromAuctionStep() {
-  currentMode.value = registrationType.value === 'inspection' ? 'inspection-pick' : 'direct'
-  submitted.value = false
-}
-
-function toggleAuctionField(field) {
-  auctionForm.value[field] = !auctionForm.value[field]
-
-  if (field === 'timeDeal') {
-    selectedDuration.value = auctionForm.value.timeDeal ? '12시간' : '5일'
-  }
-}
-
-function selectInspectionItem(index) {
-  selectedInspectionId.value = index
-  isInspectionDetailOpen.value = true
-}
-
-function closeInspectionDetail() {
-  isInspectionDetailOpen.value = false
-}
-
-function startAuctionFromInspection() {
-  isInspectionDetailOpen.value = false
-  currentMode.value = 'direct-auction'
-  submitted.value = false
-}
-
-watch(
-  () => props.initialMode,
-  (mode) => {
-    currentMode.value = allowedModes.includes(mode) ? mode : 'select'
-    registrationType.value = mode === 'inspection' || mode === 'inspection-pick' ? 'inspection' : 'direct'
-    submitted.value = false
-  },
-)
-
-onBeforeUnmount(() => {
-  uploadedImages.value.forEach((image) => {
-    if (image.previewUrl) {
-      URL.revokeObjectURL(image.previewUrl)
-    }
-  })
-})
+const {
+  auctionForm,
+  bidUnitOptions,
+  closeInspectionDetail,
+  currentMode,
+  durationOptions,
+  firstStepLabel,
+  form,
+  goBackToSelect,
+  handleFiles,
+  headerDescription,
+  headerTitle,
+  inspectionPickItems,
+  isAuctionStep,
+  isInspectionDetailOpen,
+  openMode,
+  removeImage,
+  returnFromAuctionStep,
+  selectedBidUnit,
+  selectedDuration,
+  selectedInspectionId,
+  selectedInspectionItem,
+  selectInspectionItem,
+  showStepper,
+  startAuctionFromInspection,
+  submitted,
+  submitForm,
+  successMessage,
+  thumbnailPlaceholders,
+  toggleAuctionField,
+  uploadedImages,
+} = useRegisterFlow(toRef(props, 'initialMode'))
 </script>
 
 <template>
@@ -284,389 +93,59 @@ onBeforeUnmount(() => {
       <p>{{ headerDescription }}</p>
     </header>
 
-    <div v-if="showStepper" class="register-stepper">
-      <div class="register-step" :class="{ 'is-active': !isAuctionStep }">
-        <span class="register-step-index" :class="{ 'is-muted': isAuctionStep }">1</span>
-        <span>{{ firstStepLabel }}</span>
-      </div>
-      <span class="register-step-line" />
-      <div class="register-step" :class="{ 'is-active': isAuctionStep }">
-        <span class="register-step-index" :class="{ 'is-muted': !isAuctionStep }">2</span>
-        <span>경매 등록</span>
-      </div>
-    </div>
+    <RegisterStepper
+      v-if="showStepper"
+      :first-step-label="firstStepLabel"
+      :is-auction-step="isAuctionStep"
+    />
 
-    <section v-if="currentMode === 'select'" class="register-method-grid">
-      <article
-        v-for="method in registrationMethods"
-        :key="method.title"
-        class="register-method-card"
-        :class="method.cardClass"
-      >
-        <div class="register-method-icon-wrap">
-          <img :src="method.iconSrc" :alt="method.title" class="register-method-icon" />
-        </div>
+    <RegisterMethodSelect
+      v-if="currentMode === 'select'"
+      :methods="registrationMethods"
+      @select-mode="openMode"
+    />
 
-        <h3>{{ method.title }}</h3>
+    <InspectionPickStep
+      v-else-if="currentMode === 'inspection-pick'"
+      :assets="assets"
+      :inspection-pick-items="inspectionPickItems"
+      :inspection-product-image="inspectionProductImage"
+      :is-inspection-detail-open="isInspectionDetailOpen"
+      :selected-inspection-id="selectedInspectionId"
+      :selected-inspection-item="selectedInspectionItem"
+      @close-detail="closeInspectionDetail"
+      @select-item="selectInspectionItem"
+      @start-auction="startAuctionFromInspection"
+    />
 
-        <ul class="register-method-points">
-          <li
-            v-for="point in method.points"
-            :key="point"
-            class="register-method-point"
-          >
-            <img :src="method.bulletSrc" alt="" class="register-method-bullet" />
-            <span>{{ point }}</span>
-          </li>
-        </ul>
+    <RegisterProductForm
+      v-else-if="currentMode === 'inspection' || currentMode === 'direct'"
+      :current-mode="currentMode"
+      :form="form"
+      :submitted="submitted"
+      :success-message="successMessage"
+      :thumbnail-placeholders="thumbnailPlaceholders"
+      :uploaded-images="uploadedImages"
+      @cancel="goBackToSelect"
+      @files-selected="handleFiles"
+      @remove-image="removeImage"
+      @submit="submitForm"
+    />
 
-        <button
-          type="button"
-          class="register-method-button"
-          :class="method.buttonClass"
-          @click="openMode(method.key)"
-        >
-          {{ method.buttonLabel }}
-        </button>
-      </article>
-    </section>
-
-    <section v-else-if="currentMode === 'inspection-pick'" class="register-form-card register-inspection-pick-card">
-      <div class="inspection-toolbar register-inspection-toolbar">
-        <div class="inspection-search">
-          <img :src="assets.listSearchIcon" alt="" class="inspection-search-icon" />
-          <span>상품명, 브랜드 검색</span>
-        </div>
-      </div>
-
-      <div class="inspection-card-grid register-inspection-grid">
-        <article
-          v-for="item in inspectionPickItems"
-          :key="`${item.title}-${item.displayId}`"
-          class="inspection-product-card register-inspection-card"
-          :class="{ 'is-selected': selectedInspectionId === item.displayId }"
-          @click="selectInspectionItem(item.displayId)"
-        >
-          <div class="inspection-product-image-wrap">
-            <img :src="inspectionProductImage" :alt="item.title" class="inspection-product-image" />
-            <span class="inspection-badge is-passed">검수 통과</span>
-          </div>
-
-          <div class="inspection-product-body">
-            <h3>{{ item.title }}</h3>
-            <div class="inspection-product-meta">
-              <div>
-                <span>검수 등급</span>
-                <strong>{{ item.inspectionGrade }}</strong>
-              </div>
-              <span>{{ item.inspectionDate }}</span>
-            </div>
-          </div>
-        </article>
-
-        <article class="register-empty-card">
-          <div class="register-empty-icon">+</div>
-          <strong>상품이 없으신가요?</strong>
-          <p>신규 사전 검수 상품을 등록해보세요.</p>
-        </article>
-      </div>
-
-      <div v-if="isInspectionDetailOpen && selectedInspectionItem" class="inspection-detail-overlay" @click.self="closeInspectionDetail">
-        <section class="inspection-detail-modal">
-          <button type="button" class="inspection-detail-close" @click="closeInspectionDetail">
-            ×
-          </button>
-
-          <div class="inspection-detail-grid">
-            <div class="inspection-detail-image-card">
-              <img :src="inspectionProductImage" :alt="selectedInspectionItem.title" class="inspection-detail-image" />
-            </div>
-
-            <div class="inspection-detail-summary">
-              <p class="inspection-detail-category">럭셔리 &gt; 시계 &gt; 남성용 시계</p>
-              <span class="inspection-badge is-passed">검수 통과</span>
-              <h3>{{ selectedInspectionItem.title }}</h3>
-
-              <div class="inspection-detail-meta">
-                <div>
-                  <span>브랜드</span>
-                  <strong>{{ selectedInspectionItem.brand }}</strong>
-                </div>
-                <div>
-                  <span>검수일</span>
-                  <strong>{{ selectedInspectionItem.inspectionDate }}</strong>
-                </div>
-                <div>
-                  <span>검수 등급</span>
-                  <strong class="is-grade">{{ selectedInspectionItem.inspectionGrade }}</strong>
-                </div>
-              </div>
-            </div>
-
-            <div class="inspection-detail-section">
-              <h4>상품 설명</h4>
-              <p>{{ selectedInspectionItem.description }}</p>
-            </div>
-
-            <div class="inspection-detail-section">
-              <h4>배송 정보</h4>
-              <p>우체국 택배</p>
-              <p>1928391823798</p>
-            </div>
-          </div>
-
-          <div class="inspection-detail-actions">
-            <button type="button" class="register-secondary-button" @click="closeInspectionDetail">
-              반환 신청
-            </button>
-            <button type="button" class="register-primary-button" @click="startAuctionFromInspection">
-              경매 등록
-            </button>
-          </div>
-        </section>
-      </div>
-    </section>
-
-    <section v-else-if="currentMode === 'inspection' || currentMode === 'direct'" class="register-form-card">
-      <div class="register-form-grid">
-        <div class="register-upload-column">
-          <label class="register-label">상품 이미지 <span>*</span></label>
-          <input
-            ref="fileInput"
-            class="register-hidden-input"
-            type="file"
-            accept="image/*"
-            multiple
-            @change="handleFiles"
-          />
-
-          <button type="button" class="register-upload-box" @click="openFilePicker">
-            <img
-              v-if="uploadedImages[0]"
-              :src="uploadedImages[0].previewUrl"
-              alt=""
-              class="register-main-preview"
-            />
-            <template v-else>
-              <div class="register-upload-placeholder">
-                <div class="register-upload-icon">+</div>
-                <span>이미지 업로드</span>
-              </div>
-            </template>
-          </button>
-
-          <div class="register-thumb-row">
-            <button
-              v-for="(image, index) in uploadedImages.slice(1)"
-              :key="`${image.name}-${index}`"
-              type="button"
-              class="register-thumb register-thumb-image"
-              @click="removeImage(index + 1)"
-            >
-              <img :src="image.previewUrl" :alt="image.name" />
-            </button>
-            <div
-              v-for="slot in thumbnailPlaceholders"
-              :key="`empty-${slot}`"
-              class="register-thumb"
-            />
-          </div>
-
-          <p class="register-helper-text">최대 20MB까지 업로드 가능</p>
-        </div>
-
-        <div class="register-fields-column">
-          <label class="register-field">
-            <span class="register-label">상품명 <span>*</span></span>
-            <input
-              v-model="form.name"
-              type="text"
-              :placeholder="currentMode === 'inspection' ? '상품명을 입력해 주세요.' : '상품명을 입력해주세요.'"
-            />
-          </label>
-
-          <label class="register-field">
-            <span class="register-label">카테고리 <span>*</span></span>
-            <div class="register-select-wrap">
-              <select v-model="form.category">
-                <option value="" disabled>
-                  {{ currentMode === 'inspection' ? '카테고리를 선택해 주세요.' : '카테고리를 선택해주세요.' }}
-                </option>
-                <option value="watch">시계</option>
-                <option value="bag">가방</option>
-                <option value="shoes">신발</option>
-              </select>
-            </div>
-          </label>
-
-          <label v-if="currentMode === 'direct'" class="register-field">
-            <span class="register-label">상품 상태 <span>*</span></span>
-            <div class="register-select-wrap">
-              <select v-model="form.condition">
-                <option value="" disabled>상품의 상태를 선택해주세요.</option>
-                <option value="최상">최상</option>
-                <option value="상">상</option>
-                <option value="중">중</option>
-                <option value="하">하</option>
-              </select>
-            </div>
-          </label>
-
-          <label class="register-field">
-            <span class="register-label">브랜드</span>
-            <input
-              v-model="form.brand"
-              type="text"
-              :placeholder="currentMode === 'inspection' ? '브랜드를 입력해 주세요.' : '브랜드를 입력해주세요.'"
-            />
-          </label>
-
-          <label class="register-field">
-            <span class="register-label">상세 설명 <span>*</span></span>
-            <textarea
-              v-model="form.description"
-              placeholder="구매 시기, 보증서 유무, 하자 여부 등 상세한 내용을 입력해주세요."
-            />
-          </label>
-        </div>
-      </div>
-
-      <div v-if="submitted" class="register-success-banner">
-        {{ successMessage }}
-      </div>
-
-      <div class="register-actions">
-        <button type="button" class="register-secondary-button" @click="goBackToSelect">
-          취소
-        </button>
-        <button type="button" class="register-primary-button" @click="submitForm">
-          확인
-        </button>
-      </div>
-    </section>
-
-    <section v-else class="register-form-card register-auction-card">
-      <div class="auction-settings">
-        <div class="auction-toggle-grid">
-          <article class="auction-toggle-card">
-            <div class="auction-toggle-copy">
-              <div class="auction-toggle-icon is-extend">↻</div>
-              <div>
-                <strong>연장 경매</strong>
-                <p>종료 직전 입찰 시 시간 연장</p>
-              </div>
-            </div>
-            <button
-              type="button"
-              class="auction-switch"
-              :class="{ 'is-on': auctionForm.extendAuction }"
-              @click="toggleAuctionField('extendAuction')"
-            >
-              <span />
-            </button>
-          </article>
-
-          <article class="auction-toggle-card">
-            <div class="auction-toggle-copy">
-              <div class="auction-toggle-icon is-timedeal">⚡</div>
-              <div>
-                <strong>타임딜</strong>
-                <p>단시간 내 고가가 낙찰 유도</p>
-              </div>
-            </div>
-            <button
-              type="button"
-              class="auction-switch"
-              :class="[{ 'is-on': auctionForm.timeDeal }, 'is-danger']"
-              @click="toggleAuctionField('timeDeal')"
-            >
-              <span />
-            </button>
-          </article>
-        </div>
-
-        <div class="auction-field-grid">
-          <label class="register-field">
-            <span class="register-label">경매 시작가 <span>*</span></span>
-            <div class="auction-money-field">
-              <input v-model="auctionForm.startPrice" type="number" placeholder="0" />
-              <span>원</span>
-            </div>
-          </label>
-
-          <label class="register-field">
-            <span class="register-label">즉시 구매가</span>
-            <div class="auction-money-field">
-              <input v-model="auctionForm.buyNowPrice" type="number" placeholder="0" />
-              <span>원</span>
-            </div>
-          </label>
-        </div>
-
-        <div class="auction-option-section">
-          <span class="register-label">입찰 단위 <span>*</span></span>
-          <div class="auction-chip-row">
-            <button
-              v-for="option in bidUnitOptions"
-              :key="option"
-              type="button"
-              class="auction-chip"
-              :class="{ 'is-selected': selectedBidUnit === option }"
-              @click="selectedBidUnit = option"
-            >
-              {{ option }}
-            </button>
-          </div>
-        </div>
-
-        <div class="auction-option-section">
-          <span class="register-label">경매 기간 <span>*</span></span>
-
-          <div class="auction-date-grid">
-            <div class="auction-date-card">
-              <span class="auction-date-label">시작 일시</span>
-              <div class="auction-date-value-row">
-                <div class="auction-date-value">🗓 {{ auctionForm.startDate }}</div>
-                <div class="auction-date-value">🕒 {{ auctionForm.startTime }}</div>
-              </div>
-            </div>
-
-            <div class="auction-date-card">
-              <span class="auction-date-label">종료 일시</span>
-              <div class="auction-date-value-row">
-                <div class="auction-date-value">🗓 {{ auctionForm.endDate }}</div>
-                <div class="auction-date-value">🕒 {{ auctionForm.endTime }}</div>
-              </div>
-            </div>
-          </div>
-
-          <div class="auction-chip-row is-duration">
-            <button
-              v-for="option in durationOptions"
-              :key="option"
-              type="button"
-              class="auction-chip"
-              :class="{ 'is-selected': selectedDuration === option }"
-              @click="selectedDuration = option"
-            >
-              {{ option }}
-            </button>
-          </div>
-        </div>
-
-        <div v-if="submitted" class="register-success-banner">
-          {{ successMessage }}
-        </div>
-
-        <div class="register-actions">
-          <button type="button" class="register-secondary-button" @click="returnFromAuctionStep">
-            취소
-          </button>
-          <button type="button" class="register-primary-button" @click="submitForm">
-            확인
-          </button>
-        </div>
-      </div>
-    </section>
+    <AuctionSetupForm
+      v-else
+      :auction-form="auctionForm"
+      :bid-unit-options="bidUnitOptions"
+      :duration-options="durationOptions"
+      :selected-bid-unit="selectedBidUnit"
+      :selected-duration="selectedDuration"
+      :submitted="submitted"
+      :success-message="successMessage"
+      @cancel="returnFromAuctionStep"
+      @select-bid-unit="selectedBidUnit = $event"
+      @select-duration="selectedDuration = $event"
+      @submit="submitForm"
+      @toggle-field="toggleAuctionField"
+    />
   </section>
 </template>

--- a/src/components/RegisterScreen.vue
+++ b/src/components/RegisterScreen.vue
@@ -1,0 +1,33 @@
+<script setup>
+defineProps({
+  options: {
+    type: Array,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <section class="register-screen">
+    <div class="register-header">
+      <h2>경매 등록 방법 선택</h2>
+      <p>판매 상품의 상태와 목적에 맞는 등록 방식을 선택하세요.</p>
+    </div>
+
+    <div class="register-grid">
+      <article
+        v-for="option in options"
+        :key="option.title"
+        class="register-card"
+        :class="`is-${option.tone}`"
+      >
+        <div class="register-icon">{{ option.tone === 'inspection' ? '✓' : '＋' }}</div>
+        <strong>{{ option.title }}</strong>
+        <p>{{ option.description }}</p>
+        <button type="button" class="register-button">
+          {{ option.button }}
+        </button>
+      </article>
+    </div>
+  </section>
+</template>

--- a/src/components/RegisterScreen.vue
+++ b/src/components/RegisterScreen.vue
@@ -1,33 +1,672 @@
 <script setup>
-defineProps({
-  options: {
-    type: Array,
-    required: true,
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { assets, inspectionItems } from '../data/marketplaceData'
+
+const inspectionIcon = 'https://www.figma.com/api/mcp/asset/d5a99cb7-a2ca-482c-b0ca-24c4ff52d162'
+const directIcon = 'https://www.figma.com/api/mcp/asset/f2c463ba-f81c-4eba-8631-58c625f3d89b'
+const checkBullet = 'https://www.figma.com/api/mcp/asset/22001c49-ae72-4074-8e82-fb905a0e3640'
+const infoBullet = 'https://www.figma.com/api/mcp/asset/f9c860bc-f862-4836-b1e9-b0ea19594b4d'
+const inspectionProductImage = 'https://www.figma.com/api/mcp/asset/32f14895-b803-4f5e-ae62-afb42f566620'
+
+const props = defineProps({
+  initialMode: {
+    type: String,
+    default: 'select',
   },
+})
+
+const allowedModes = ['select', 'inspection', 'inspection-pick', 'direct', 'direct-auction']
+const currentMode = ref(allowedModes.includes(props.initialMode) ? props.initialMode : 'select')
+const registrationType = ref(
+  props.initialMode === 'inspection' || props.initialMode === 'inspection-pick' ? 'inspection' : 'direct',
+)
+const fileInput = ref(null)
+const submitted = ref(false)
+const uploadedImages = ref([])
+const selectedBidUnit = ref('10,000')
+const selectedDuration = ref('5일')
+const selectedInspectionId = ref(0)
+const isInspectionDetailOpen = ref(false)
+
+const form = ref({
+  name: '',
+  category: '',
+  brand: '',
+  condition: '',
+  description: '',
+})
+
+const auctionForm = ref({
+  extendAuction: true,
+  timeDeal: false,
+  startPrice: '',
+  buyNowPrice: '',
+  startDate: '2024 / 03 / 27',
+  startTime: '12 : 00 : 00',
+  endDate: '2024 / 03 / 27',
+  endTime: '12 : 00 : 00',
+})
+
+const registrationMethods = [
+  {
+    key: 'inspection-pick',
+    title: '사전 검수 상품 등록',
+    points: [
+      '검수 완료된 상품만 골라 바로 경매에 등록할 수 있습니다.',
+      '검수 정보와 등급이 함께 노출되어 입찰 신뢰도가 높습니다.',
+      '상품 선택 후 바로 2단계 경매 등록으로 이어집니다.',
+    ],
+    buttonLabel: '검수 상품 등록하기',
+    cardClass: 'is-inspection',
+    buttonClass: 'is-inspection',
+    iconSrc: inspectionIcon,
+    bulletSrc: checkBullet,
+  },
+  {
+    key: 'direct',
+    title: '직접 상품 등록',
+    points: [
+      '판매자가 직접 사진 설명 및 상품 정보를 입력합니다.',
+      '검수 절차 없이 빠르게 상품을 등록할 수 있습니다.',
+      '낙찰 후 구매자와 직접 배송 및 거래를 진행합니다.',
+    ],
+    buttonLabel: '직접 등록하기',
+    cardClass: 'is-direct',
+    buttonClass: 'is-direct',
+    iconSrc: directIcon,
+    bulletSrc: infoBullet,
+  },
+]
+
+const headerTitle = computed(() => {
+  if (currentMode.value === 'inspection') {
+    return '검수 상품 신청'
+  }
+
+  if (currentMode.value === 'inspection-pick') {
+    return '사전 검수 상품 등록'
+  }
+
+  if (currentMode.value === 'direct') {
+    return '직접 상품 등록'
+  }
+
+  if (currentMode.value === 'direct-auction') {
+    return '경매 등록'
+  }
+
+  return '경매 등록 방법 선택'
+})
+
+const headerDescription = computed(() => {
+  if (currentMode.value === 'inspection') {
+    return '검수 상품 정보를 입력해주세요.'
+  }
+
+  if (currentMode.value === 'inspection-pick') {
+    return '검수가 완료된 상품을 선택해 경매에 등록해주세요.'
+  }
+
+  if (currentMode.value === 'direct') {
+    return '경매에 등록할 상품 정보를 입력해주세요.'
+  }
+
+  if (currentMode.value === 'direct-auction') {
+    return '경매 정보를 입력해주세요.'
+  }
+
+  return '경매 등록하실 방법을 선택해주세요.'
+})
+
+const thumbnailPlaceholders = computed(() =>
+  Math.max(0, 3 - Math.max(0, uploadedImages.value.length - 1)),
+)
+
+const successMessage = computed(() =>
+  currentMode.value === 'inspection'
+    ? '더미 데이터 기준으로 검수 상품 신청이 완료되었습니다.'
+    : currentMode.value === 'direct-auction'
+      ? registrationType.value === 'inspection'
+        ? '더미 데이터 기준으로 사전 검수 상품 경매 등록이 완료되었습니다.'
+        : '더미 데이터 기준으로 경매 등록이 완료되었습니다.'
+      : '더미 데이터 기준으로 직접 상품 등록이 완료되었습니다.',
+)
+
+const showStepper = computed(() =>
+  currentMode.value === 'inspection-pick' || currentMode.value === 'direct' || currentMode.value === 'direct-auction',
+)
+
+const isAuctionStep = computed(() => currentMode.value === 'direct-auction')
+const firstStepLabel = computed(() =>
+  registrationType.value === 'inspection' ? '사전 검수 상품 등록' : '직접 상품 등록',
+)
+const bidUnitOptions = ['1,000', '5,000', '10,000', '50,000', '100,000', '직접입력']
+const durationOptions = computed(() =>
+  auctionForm.value.timeDeal
+    ? ['4시간', '8시간', '12시간', '16시간', '20시간', '24시간', '28시간', '32시간', '36시간', '40시간', '44시간', '48시간']
+    : ['3일', '4일', '5일', '6일', '7일', '8일', '9일', '10일'],
+)
+const inspectionReadyItems = computed(() =>
+  inspectionItems.filter((item) => item.status === '검수 통과'),
+)
+const selectedInspectionItem = computed(() =>
+  inspectionReadyItems.value.length
+    ? inspectionReadyItems.value[selectedInspectionId.value % inspectionReadyItems.value.length]
+    : null,
+)
+const inspectionPickItems = computed(() => {
+  if (!inspectionReadyItems.value.length) {
+    return []
+  }
+
+  return Array.from({ length: 7 }, (_, index) => ({
+    ...inspectionReadyItems.value[index % inspectionReadyItems.value.length],
+    displayId: index,
+  }))
+})
+
+function openMode(mode) {
+  registrationType.value = mode === 'inspection' || mode === 'inspection-pick' ? 'inspection' : 'direct'
+  currentMode.value = mode
+  submitted.value = false
+}
+
+function openFilePicker() {
+  fileInput.value?.click()
+}
+
+function handleFiles(event) {
+  const files = Array.from(event.target.files || [])
+  const remain = Math.max(0, 4 - uploadedImages.value.length)
+  const selected = files.slice(0, remain)
+
+  selected.forEach((file) => {
+    uploadedImages.value.push({
+      name: file.name,
+      previewUrl: URL.createObjectURL(file),
+    })
+  })
+
+  event.target.value = ''
+}
+
+function removeImage(index) {
+  const [image] = uploadedImages.value.splice(index, 1)
+
+  if (image?.previewUrl) {
+    URL.revokeObjectURL(image.previewUrl)
+  }
+}
+
+function resetForm() {
+  uploadedImages.value.forEach((image) => {
+    if (image.previewUrl) {
+      URL.revokeObjectURL(image.previewUrl)
+    }
+  })
+
+  uploadedImages.value = []
+  form.value = {
+    name: '',
+    category: '',
+    brand: '',
+    condition: '',
+    description: '',
+  }
+  submitted.value = false
+}
+
+function goBackToSelect() {
+  resetForm()
+  currentMode.value = 'select'
+}
+
+function submitForm() {
+  if (currentMode.value === 'direct' || currentMode.value === 'inspection-pick') {
+    currentMode.value = 'direct-auction'
+    submitted.value = false
+    return
+  }
+
+  submitted.value = true
+}
+
+function returnFromAuctionStep() {
+  currentMode.value = registrationType.value === 'inspection' ? 'inspection-pick' : 'direct'
+  submitted.value = false
+}
+
+function toggleAuctionField(field) {
+  auctionForm.value[field] = !auctionForm.value[field]
+
+  if (field === 'timeDeal') {
+    selectedDuration.value = auctionForm.value.timeDeal ? '12시간' : '5일'
+  }
+}
+
+function selectInspectionItem(index) {
+  selectedInspectionId.value = index
+  isInspectionDetailOpen.value = true
+}
+
+function closeInspectionDetail() {
+  isInspectionDetailOpen.value = false
+}
+
+function startAuctionFromInspection() {
+  isInspectionDetailOpen.value = false
+  currentMode.value = 'direct-auction'
+  submitted.value = false
+}
+
+watch(
+  () => props.initialMode,
+  (mode) => {
+    currentMode.value = allowedModes.includes(mode) ? mode : 'select'
+    registrationType.value = mode === 'inspection' || mode === 'inspection-pick' ? 'inspection' : 'direct'
+    submitted.value = false
+  },
+)
+
+onBeforeUnmount(() => {
+  uploadedImages.value.forEach((image) => {
+    if (image.previewUrl) {
+      URL.revokeObjectURL(image.previewUrl)
+    }
+  })
 })
 </script>
 
 <template>
   <section class="register-screen">
-    <div class="register-header">
-      <h2>경매 등록 방법 선택</h2>
-      <p>판매 상품의 상태와 목적에 맞는 등록 방식을 선택하세요.</p>
+    <header class="register-method-header">
+      <h2>{{ headerTitle }}</h2>
+      <p>{{ headerDescription }}</p>
+    </header>
+
+    <div v-if="showStepper" class="register-stepper">
+      <div class="register-step" :class="{ 'is-active': !isAuctionStep }">
+        <span class="register-step-index" :class="{ 'is-muted': isAuctionStep }">1</span>
+        <span>{{ firstStepLabel }}</span>
+      </div>
+      <span class="register-step-line" />
+      <div class="register-step" :class="{ 'is-active': isAuctionStep }">
+        <span class="register-step-index" :class="{ 'is-muted': !isAuctionStep }">2</span>
+        <span>경매 등록</span>
+      </div>
     </div>
 
-    <div class="register-grid">
+    <section v-if="currentMode === 'select'" class="register-method-grid">
       <article
-        v-for="option in options"
-        :key="option.title"
-        class="register-card"
-        :class="`is-${option.tone}`"
+        v-for="method in registrationMethods"
+        :key="method.title"
+        class="register-method-card"
+        :class="method.cardClass"
       >
-        <div class="register-icon">{{ option.tone === 'inspection' ? '✓' : '＋' }}</div>
-        <strong>{{ option.title }}</strong>
-        <p>{{ option.description }}</p>
-        <button type="button" class="register-button">
-          {{ option.button }}
+        <div class="register-method-icon-wrap">
+          <img :src="method.iconSrc" :alt="method.title" class="register-method-icon" />
+        </div>
+
+        <h3>{{ method.title }}</h3>
+
+        <ul class="register-method-points">
+          <li
+            v-for="point in method.points"
+            :key="point"
+            class="register-method-point"
+          >
+            <img :src="method.bulletSrc" alt="" class="register-method-bullet" />
+            <span>{{ point }}</span>
+          </li>
+        </ul>
+
+        <button
+          type="button"
+          class="register-method-button"
+          :class="method.buttonClass"
+          @click="openMode(method.key)"
+        >
+          {{ method.buttonLabel }}
         </button>
       </article>
-    </div>
+    </section>
+
+    <section v-else-if="currentMode === 'inspection-pick'" class="register-form-card register-inspection-pick-card">
+      <div class="inspection-toolbar register-inspection-toolbar">
+        <div class="inspection-search">
+          <img :src="assets.listSearchIcon" alt="" class="inspection-search-icon" />
+          <span>상품명, 브랜드 검색</span>
+        </div>
+      </div>
+
+      <div class="inspection-card-grid register-inspection-grid">
+        <article
+          v-for="item in inspectionPickItems"
+          :key="`${item.title}-${item.displayId}`"
+          class="inspection-product-card register-inspection-card"
+          :class="{ 'is-selected': selectedInspectionId === item.displayId }"
+          @click="selectInspectionItem(item.displayId)"
+        >
+          <div class="inspection-product-image-wrap">
+            <img :src="inspectionProductImage" :alt="item.title" class="inspection-product-image" />
+            <span class="inspection-badge is-passed">검수 통과</span>
+          </div>
+
+          <div class="inspection-product-body">
+            <h3>{{ item.title }}</h3>
+            <div class="inspection-product-meta">
+              <div>
+                <span>검수 등급</span>
+                <strong>{{ item.inspectionGrade }}</strong>
+              </div>
+              <span>{{ item.inspectionDate }}</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="register-empty-card">
+          <div class="register-empty-icon">+</div>
+          <strong>상품이 없으신가요?</strong>
+          <p>신규 사전 검수 상품을 등록해보세요.</p>
+        </article>
+      </div>
+
+      <div v-if="isInspectionDetailOpen && selectedInspectionItem" class="inspection-detail-overlay" @click.self="closeInspectionDetail">
+        <section class="inspection-detail-modal">
+          <button type="button" class="inspection-detail-close" @click="closeInspectionDetail">
+            ×
+          </button>
+
+          <div class="inspection-detail-grid">
+            <div class="inspection-detail-image-card">
+              <img :src="inspectionProductImage" :alt="selectedInspectionItem.title" class="inspection-detail-image" />
+            </div>
+
+            <div class="inspection-detail-summary">
+              <p class="inspection-detail-category">럭셔리 &gt; 시계 &gt; 남성용 시계</p>
+              <span class="inspection-badge is-passed">검수 통과</span>
+              <h3>{{ selectedInspectionItem.title }}</h3>
+
+              <div class="inspection-detail-meta">
+                <div>
+                  <span>브랜드</span>
+                  <strong>{{ selectedInspectionItem.brand }}</strong>
+                </div>
+                <div>
+                  <span>검수일</span>
+                  <strong>{{ selectedInspectionItem.inspectionDate }}</strong>
+                </div>
+                <div>
+                  <span>검수 등급</span>
+                  <strong class="is-grade">{{ selectedInspectionItem.inspectionGrade }}</strong>
+                </div>
+              </div>
+            </div>
+
+            <div class="inspection-detail-section">
+              <h4>상품 설명</h4>
+              <p>{{ selectedInspectionItem.description }}</p>
+            </div>
+
+            <div class="inspection-detail-section">
+              <h4>배송 정보</h4>
+              <p>우체국 택배</p>
+              <p>1928391823798</p>
+            </div>
+          </div>
+
+          <div class="inspection-detail-actions">
+            <button type="button" class="register-secondary-button" @click="closeInspectionDetail">
+              반환 신청
+            </button>
+            <button type="button" class="register-primary-button" @click="startAuctionFromInspection">
+              경매 등록
+            </button>
+          </div>
+        </section>
+      </div>
+    </section>
+
+    <section v-else-if="currentMode === 'inspection' || currentMode === 'direct'" class="register-form-card">
+      <div class="register-form-grid">
+        <div class="register-upload-column">
+          <label class="register-label">상품 이미지 <span>*</span></label>
+          <input
+            ref="fileInput"
+            class="register-hidden-input"
+            type="file"
+            accept="image/*"
+            multiple
+            @change="handleFiles"
+          />
+
+          <button type="button" class="register-upload-box" @click="openFilePicker">
+            <img
+              v-if="uploadedImages[0]"
+              :src="uploadedImages[0].previewUrl"
+              alt=""
+              class="register-main-preview"
+            />
+            <template v-else>
+              <div class="register-upload-placeholder">
+                <div class="register-upload-icon">+</div>
+                <span>이미지 업로드</span>
+              </div>
+            </template>
+          </button>
+
+          <div class="register-thumb-row">
+            <button
+              v-for="(image, index) in uploadedImages.slice(1)"
+              :key="`${image.name}-${index}`"
+              type="button"
+              class="register-thumb register-thumb-image"
+              @click="removeImage(index + 1)"
+            >
+              <img :src="image.previewUrl" :alt="image.name" />
+            </button>
+            <div
+              v-for="slot in thumbnailPlaceholders"
+              :key="`empty-${slot}`"
+              class="register-thumb"
+            />
+          </div>
+
+          <p class="register-helper-text">최대 20MB까지 업로드 가능</p>
+        </div>
+
+        <div class="register-fields-column">
+          <label class="register-field">
+            <span class="register-label">상품명 <span>*</span></span>
+            <input
+              v-model="form.name"
+              type="text"
+              :placeholder="currentMode === 'inspection' ? '상품명을 입력해 주세요.' : '상품명을 입력해주세요.'"
+            />
+          </label>
+
+          <label class="register-field">
+            <span class="register-label">카테고리 <span>*</span></span>
+            <div class="register-select-wrap">
+              <select v-model="form.category">
+                <option value="" disabled>
+                  {{ currentMode === 'inspection' ? '카테고리를 선택해 주세요.' : '카테고리를 선택해주세요.' }}
+                </option>
+                <option value="watch">시계</option>
+                <option value="bag">가방</option>
+                <option value="shoes">신발</option>
+              </select>
+            </div>
+          </label>
+
+          <label v-if="currentMode === 'direct'" class="register-field">
+            <span class="register-label">상품 상태 <span>*</span></span>
+            <div class="register-select-wrap">
+              <select v-model="form.condition">
+                <option value="" disabled>상품의 상태를 선택해주세요.</option>
+                <option value="최상">최상</option>
+                <option value="상">상</option>
+                <option value="중">중</option>
+                <option value="하">하</option>
+              </select>
+            </div>
+          </label>
+
+          <label class="register-field">
+            <span class="register-label">브랜드</span>
+            <input
+              v-model="form.brand"
+              type="text"
+              :placeholder="currentMode === 'inspection' ? '브랜드를 입력해 주세요.' : '브랜드를 입력해주세요.'"
+            />
+          </label>
+
+          <label class="register-field">
+            <span class="register-label">상세 설명 <span>*</span></span>
+            <textarea
+              v-model="form.description"
+              placeholder="구매 시기, 보증서 유무, 하자 여부 등 상세한 내용을 입력해주세요."
+            />
+          </label>
+        </div>
+      </div>
+
+      <div v-if="submitted" class="register-success-banner">
+        {{ successMessage }}
+      </div>
+
+      <div class="register-actions">
+        <button type="button" class="register-secondary-button" @click="goBackToSelect">
+          취소
+        </button>
+        <button type="button" class="register-primary-button" @click="submitForm">
+          확인
+        </button>
+      </div>
+    </section>
+
+    <section v-else class="register-form-card register-auction-card">
+      <div class="auction-settings">
+        <div class="auction-toggle-grid">
+          <article class="auction-toggle-card">
+            <div class="auction-toggle-copy">
+              <div class="auction-toggle-icon is-extend">↻</div>
+              <div>
+                <strong>연장 경매</strong>
+                <p>종료 직전 입찰 시 시간 연장</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              class="auction-switch"
+              :class="{ 'is-on': auctionForm.extendAuction }"
+              @click="toggleAuctionField('extendAuction')"
+            >
+              <span />
+            </button>
+          </article>
+
+          <article class="auction-toggle-card">
+            <div class="auction-toggle-copy">
+              <div class="auction-toggle-icon is-timedeal">⚡</div>
+              <div>
+                <strong>타임딜</strong>
+                <p>단시간 내 고가가 낙찰 유도</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              class="auction-switch"
+              :class="[{ 'is-on': auctionForm.timeDeal }, 'is-danger']"
+              @click="toggleAuctionField('timeDeal')"
+            >
+              <span />
+            </button>
+          </article>
+        </div>
+
+        <div class="auction-field-grid">
+          <label class="register-field">
+            <span class="register-label">경매 시작가 <span>*</span></span>
+            <div class="auction-money-field">
+              <input v-model="auctionForm.startPrice" type="number" placeholder="0" />
+              <span>원</span>
+            </div>
+          </label>
+
+          <label class="register-field">
+            <span class="register-label">즉시 구매가</span>
+            <div class="auction-money-field">
+              <input v-model="auctionForm.buyNowPrice" type="number" placeholder="0" />
+              <span>원</span>
+            </div>
+          </label>
+        </div>
+
+        <div class="auction-option-section">
+          <span class="register-label">입찰 단위 <span>*</span></span>
+          <div class="auction-chip-row">
+            <button
+              v-for="option in bidUnitOptions"
+              :key="option"
+              type="button"
+              class="auction-chip"
+              :class="{ 'is-selected': selectedBidUnit === option }"
+              @click="selectedBidUnit = option"
+            >
+              {{ option }}
+            </button>
+          </div>
+        </div>
+
+        <div class="auction-option-section">
+          <span class="register-label">경매 기간 <span>*</span></span>
+
+          <div class="auction-date-grid">
+            <div class="auction-date-card">
+              <span class="auction-date-label">시작 일시</span>
+              <div class="auction-date-value-row">
+                <div class="auction-date-value">🗓 {{ auctionForm.startDate }}</div>
+                <div class="auction-date-value">🕒 {{ auctionForm.startTime }}</div>
+              </div>
+            </div>
+
+            <div class="auction-date-card">
+              <span class="auction-date-label">종료 일시</span>
+              <div class="auction-date-value-row">
+                <div class="auction-date-value">🗓 {{ auctionForm.endDate }}</div>
+                <div class="auction-date-value">🕒 {{ auctionForm.endTime }}</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="auction-chip-row is-duration">
+            <button
+              v-for="option in durationOptions"
+              :key="option"
+              type="button"
+              class="auction-chip"
+              :class="{ 'is-selected': selectedDuration === option }"
+              @click="selectedDuration = option"
+            >
+              {{ option }}
+            </button>
+          </div>
+        </div>
+
+        <div v-if="submitted" class="register-success-banner">
+          {{ successMessage }}
+        </div>
+
+        <div class="register-actions">
+          <button type="button" class="register-secondary-button" @click="returnFromAuctionStep">
+            취소
+          </button>
+          <button type="button" class="register-primary-button" @click="submitForm">
+            확인
+          </button>
+        </div>
+      </div>
+    </section>
   </section>
 </template>

--- a/src/components/auction-detail/BidHistoryDrawer.vue
+++ b/src/components/auction-detail/BidHistoryDrawer.vue
@@ -1,0 +1,63 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+  rows: {
+    type: Array,
+    required: true,
+  },
+})
+
+defineEmits(['close', 'open-bid'])
+</script>
+
+<template>
+  <div class="detail-history-drawer-overlay" @click.self="$emit('close')">
+    <aside class="detail-history-drawer">
+      <div class="detail-history-drawer-top">
+        <button type="button" class="detail-history-drawer-close" @click="$emit('close')">
+          ×
+        </button>
+      </div>
+
+      <div class="detail-history-drawer-summary">
+        <img :src="assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
+        <div class="detail-inquiry-summary-copy">
+          <strong>{{ item.title }}</strong>
+          <span>현재 입찰가</span>
+          <em>{{ item.price }}원</em>
+        </div>
+      </div>
+
+      <div class="detail-history-table">
+        <div class="detail-history-table-head">
+          <span>입찰자</span>
+          <span>입찰액</span>
+          <span>입찰 일시</span>
+        </div>
+
+        <div class="detail-history-table-body">
+          <div
+            v-for="(row, index) in rows"
+            :key="`${row.bidder}-${index}`"
+            class="detail-history-table-row"
+          >
+            <span>{{ row.bidder }}</span>
+            <strong>{{ row.amount }}</strong>
+            <span>{{ row.date }}</span>
+          </div>
+        </div>
+      </div>
+
+      <button type="button" class="detail-history-action" @click="$emit('open-bid')">
+        입찰하기
+      </button>
+    </aside>
+  </div>
+</template>

--- a/src/components/auction-detail/BidModal.vue
+++ b/src/components/auction-detail/BidModal.vue
@@ -1,4 +1,6 @@
 <script setup>
+import BaseModal from '../shared/BaseModal.vue'
+
 defineProps({
   assets: {
     type: Object,
@@ -30,13 +32,7 @@ defineEmits(['buy-now', 'close', 'step-bid', 'submit-bid', 'update:bidAmount'])
 </script>
 
 <template>
-  <div class="detail-inquiry-overlay" @click.self="$emit('close')">
-    <section class="detail-bid-modal">
-      <div class="detail-inquiry-header">
-        <h3>입찰하기</h3>
-        <button type="button" class="detail-inquiry-close" @click="$emit('close')">×</button>
-      </div>
-
+  <BaseModal panel-class="detail-bid-modal" title="입찰하기" @close="$emit('close')">
       <div class="detail-inquiry-summary">
         <img :src="assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
         <div class="detail-inquiry-summary-copy">
@@ -79,6 +75,5 @@ defineEmits(['buy-now', 'close', 'step-bid', 'submit-bid', 'update:bidAmount'])
           입찰하기
         </button>
       </div>
-    </section>
-  </div>
+  </BaseModal>
 </template>

--- a/src/components/auction-detail/BidModal.vue
+++ b/src/components/auction-detail/BidModal.vue
@@ -1,0 +1,84 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  bidAmount: {
+    type: String,
+    required: true,
+  },
+  buyNowAmount: {
+    type: Number,
+    required: true,
+  },
+  formatAmount: {
+    type: Function,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+  minimumBidAmount: {
+    type: Number,
+    required: true,
+  },
+})
+
+defineEmits(['buy-now', 'close', 'step-bid', 'submit-bid', 'update:bidAmount'])
+</script>
+
+<template>
+  <div class="detail-inquiry-overlay" @click.self="$emit('close')">
+    <section class="detail-bid-modal">
+      <div class="detail-inquiry-header">
+        <h3>입찰하기</h3>
+        <button type="button" class="detail-inquiry-close" @click="$emit('close')">×</button>
+      </div>
+
+      <div class="detail-inquiry-summary">
+        <img :src="assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
+        <div class="detail-inquiry-summary-copy">
+          <strong>{{ item.title }}</strong>
+          <span>현재 입찰가</span>
+          <em>{{ item.price }}원</em>
+        </div>
+      </div>
+
+      <div class="detail-bid-modal-body">
+        <div class="detail-bid-meta-row">
+          <span>입찰 단위</span>
+          <strong>{{ item.bidUnit }}원</strong>
+        </div>
+
+        <label class="detail-bid-modal-label">입찰 금액</label>
+
+        <label class="detail-bid-input-row">
+          <input
+            :value="bidAmount"
+            type="text"
+            :placeholder="`최소 ${formatAmount(minimumBidAmount)}`"
+            @input="$emit('update:bidAmount', $event.target.value)"
+          />
+          <span>원</span>
+        </label>
+
+        <div class="detail-bid-quick-actions">
+          <button type="button" class="detail-bid-quick-chip" @click="$emit('step-bid', -1)">- {{ item.bidUnit }}</button>
+          <button type="button" class="detail-bid-quick-chip" @click="$emit('step-bid', 1)">+ {{ item.bidUnit }}</button>
+        </div>
+      </div>
+
+      <div class="detail-bid-modal-actions">
+        <button type="button" class="detail-buy-now-button" @click="$emit('buy-now')">
+          <span>{{ formatAmount(buyNowAmount) }}원 으로</span>
+          <strong>즉시 구매</strong>
+        </button>
+        <button type="button" class="detail-bid-submit-button" @click="$emit('submit-bid')">
+          입찰하기
+        </button>
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/components/auction-detail/DetailMediaSection.vue
+++ b/src/components/auction-detail/DetailMediaSection.vue
@@ -1,0 +1,30 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <div class="detail-left">
+    <div class="detail-image-card">
+      <img :src="assets.listWatchImage" :alt="item.title" class="detail-image" />
+      <button type="button" class="gallery-arrow gallery-arrow-left">‹</button>
+      <button type="button" class="gallery-arrow gallery-arrow-right">›</button>
+    </div>
+
+    <div class="inspection-banner">
+      <div class="inspection-icon">✓</div>
+      <div>
+        <strong>{{ item.inspectionLabel }}</strong>
+        <p>{{ item.inspectionDescription }}</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/auction-detail/HistoryPanel.vue
+++ b/src/components/auction-detail/HistoryPanel.vue
@@ -1,4 +1,6 @@
 <script setup>
+import SectionHeader from '../shared/SectionHeader.vue'
+
 defineProps({
   item: {
     type: Object,
@@ -11,10 +13,14 @@ defineEmits(['view-all'])
 
 <template>
   <div class="history-panel">
-    <div class="history-header">
-      <div class="history-heading">입찰 기록</div>
-      <button type="button" class="history-view-all" @click="$emit('view-all')">View All</button>
-    </div>
+    <SectionHeader
+      action-class="history-view-all"
+      action-label="View All"
+      title="입찰 기록"
+      title-class="history-heading"
+      wrapper-class="history-header"
+      @action="$emit('view-all')"
+    />
     <div class="history-list">
       <div v-for="(row, index) in item.history" :key="`${row.bidder}-${index}`" class="history-row">
         <span>{{ row.bidder }}</span>

--- a/src/components/auction-detail/HistoryPanel.vue
+++ b/src/components/auction-detail/HistoryPanel.vue
@@ -1,0 +1,26 @@
+<script setup>
+defineProps({
+  item: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['view-all'])
+</script>
+
+<template>
+  <div class="history-panel">
+    <div class="history-header">
+      <div class="history-heading">입찰 기록</div>
+      <button type="button" class="history-view-all" @click="$emit('view-all')">View All</button>
+    </div>
+    <div class="history-list">
+      <div v-for="(row, index) in item.history" :key="`${row.bidder}-${index}`" class="history-row">
+        <span>{{ row.bidder }}</span>
+        <strong>{{ row.amount }}</strong>
+        <span>{{ row.date }}</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/auction-detail/InquiryModal.vue
+++ b/src/components/auction-detail/InquiryModal.vue
@@ -1,4 +1,6 @@
 <script setup>
+import BaseModal from '../shared/BaseModal.vue'
+
 defineProps({
   assets: {
     type: Object,
@@ -18,13 +20,7 @@ defineEmits(['close', 'submit'])
 </script>
 
 <template>
-  <div class="detail-inquiry-overlay" @click.self="$emit('close')">
-    <section class="detail-inquiry-modal">
-      <div class="detail-inquiry-header">
-        <h3>문의하기</h3>
-        <button type="button" class="detail-inquiry-close" @click="$emit('close')">×</button>
-      </div>
-
+  <BaseModal panel-class="detail-inquiry-modal" title="문의하기" @close="$emit('close')">
       <div class="detail-inquiry-summary">
         <img :src="assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
         <div class="detail-inquiry-summary-copy">
@@ -61,6 +57,5 @@ defineEmits(['close', 'submit'])
       <button type="button" class="detail-inquiry-submit" @click="$emit('submit')">
         문의하기
       </button>
-    </section>
-  </div>
+  </BaseModal>
 </template>

--- a/src/components/auction-detail/InquiryModal.vue
+++ b/src/components/auction-detail/InquiryModal.vue
@@ -1,0 +1,66 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  form: {
+    type: Object,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['close', 'submit'])
+</script>
+
+<template>
+  <div class="detail-inquiry-overlay" @click.self="$emit('close')">
+    <section class="detail-inquiry-modal">
+      <div class="detail-inquiry-header">
+        <h3>문의하기</h3>
+        <button type="button" class="detail-inquiry-close" @click="$emit('close')">×</button>
+      </div>
+
+      <div class="detail-inquiry-summary">
+        <img :src="assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
+        <div class="detail-inquiry-summary-copy">
+          <strong>{{ item.title }}</strong>
+          <span>현재 입찰가</span>
+          <em>{{ item.price }}원</em>
+        </div>
+      </div>
+
+      <label class="detail-inquiry-secret">
+        <input v-model="form.isPrivate" type="checkbox" />
+        <span>비밀글</span>
+      </label>
+
+      <div class="detail-inquiry-fields">
+        <label class="detail-inquiry-field">
+          <span>문의 제목 <em>*</em></span>
+          <input
+            v-model="form.title"
+            type="text"
+            placeholder="제목을 입력해 주세요."
+          />
+        </label>
+
+        <label class="detail-inquiry-field">
+          <span>문의 내용 <em>*</em></span>
+          <textarea
+            v-model="form.content"
+            placeholder="문의 내용을 상세히 작성해주세요."
+          />
+        </label>
+      </div>
+
+      <button type="button" class="detail-inquiry-submit" @click="$emit('submit')">
+        문의하기
+      </button>
+    </section>
+  </div>
+</template>

--- a/src/components/auction-detail/InquirySection.vue
+++ b/src/components/auction-detail/InquirySection.vue
@@ -1,0 +1,45 @@
+<script setup>
+defineProps({
+  item: {
+    type: Object,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <div class="inquiry-section">
+    <div class="inquiry-heading">상품 문의 (2)</div>
+    <div class="inquiry-list">
+      <article
+        v-for="(inquiry, index) in item.inquiries"
+        :key="`${inquiry.title}-${index}`"
+        class="inquiry-item"
+        :class="{ 'is-expanded': index === 0 }"
+      >
+        <div class="inquiry-summary">
+          <div class="inquiry-summary-left">
+            <span class="status-badge" :class="{ 'is-pending': inquiry.status === '답변 대기' }">
+              {{ inquiry.status }}
+            </span>
+            <div class="inquiry-text">
+              <strong>{{ inquiry.title }}</strong>
+              <span>{{ inquiry.meta }}</span>
+            </div>
+          </div>
+          <span class="inquiry-toggle">{{ index === 0 ? '⌃' : '⌄' }}</span>
+        </div>
+
+        <div v-if="index === 0" class="inquiry-detail">
+          <div class="question-box">
+            {{ inquiry.question }}
+          </div>
+          <div class="answer-box">
+            <div class="answer-label">판매자 답변</div>
+            <p>{{ inquiry.answer }}</p>
+          </div>
+        </div>
+      </article>
+    </div>
+  </div>
+</template>

--- a/src/components/auction-detail/PricePanel.vue
+++ b/src/components/auction-detail/PricePanel.vue
@@ -1,0 +1,54 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['open-bid'])
+</script>
+
+<template>
+  <div class="price-panel">
+    <div class="price-top-line">
+      <div class="price-tags">
+        <span class="price-tag is-danger">TIME DEAL</span>
+        <span class="price-tag is-light">검수 완료</span>
+      </div>
+      <button type="button" class="detail-heart-button">
+        <img :src="assets.heartIcon" alt="" />
+      </button>
+    </div>
+
+    <p class="detail-brand-line">{{ item.brand }} |</p>
+    <h2 class="detail-product-title">{{ item.title }}</h2>
+
+    <div class="detail-price-block">
+      <span>현재 입찰가</span>
+      <strong>{{ item.price }}</strong>
+    </div>
+
+    <p class="detail-price-meta">{{ item.bids }} | 시작가 {{ item.price }}</p>
+    <p class="detail-time-left">{{ item.time }}</p>
+
+    <div class="detail-bid-box">
+      <label class="detail-bid-field">
+        <span>입찰 금액</span>
+        <input type="text" :value="item.price" />
+      </label>
+      <button type="button" class="detail-bid-button" @click="$emit('open-bid')">지금 입찰하기</button>
+    </div>
+
+    <div class="detail-stats">
+      <div><span>입찰 단위</span><strong>{{ item.bidUnit }}</strong></div>
+      <div><span>즉시 구매가</span><strong>{{ item.buyNowPrice }}</strong></div>
+      <div><span>시작일</span><strong>{{ item.startDate }}</strong></div>
+      <div><span>종료일</span><strong>{{ item.endDate }}</strong></div>
+    </div>
+  </div>
+</template>

--- a/src/components/auction-detail/ReportModal.vue
+++ b/src/components/auction-detail/ReportModal.vue
@@ -1,4 +1,6 @@
 <script setup>
+import BaseModal from '../shared/BaseModal.vue'
+
 defineProps({
   assets: {
     type: Object,
@@ -22,13 +24,7 @@ defineEmits(['close', 'submit'])
 </script>
 
 <template>
-  <div class="detail-inquiry-overlay" @click.self="$emit('close')">
-    <section class="detail-report-modal">
-      <div class="detail-inquiry-header">
-        <h3>신고하기</h3>
-        <button type="button" class="detail-inquiry-close" @click="$emit('close')">×</button>
-      </div>
-
+  <BaseModal panel-class="detail-report-modal" title="신고하기" @close="$emit('close')">
       <div class="detail-inquiry-summary">
         <img :src="assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
         <div class="detail-inquiry-summary-copy">
@@ -69,6 +65,5 @@ defineEmits(['close', 'submit'])
       <button type="button" class="detail-report-submit" @click="$emit('submit')">
         신고하기
       </button>
-    </section>
-  </div>
+  </BaseModal>
 </template>

--- a/src/components/auction-detail/ReportModal.vue
+++ b/src/components/auction-detail/ReportModal.vue
@@ -1,0 +1,74 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  form: {
+    type: Object,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+  reportTypes: {
+    type: Array,
+    required: true,
+  },
+})
+
+defineEmits(['close', 'submit'])
+</script>
+
+<template>
+  <div class="detail-inquiry-overlay" @click.self="$emit('close')">
+    <section class="detail-report-modal">
+      <div class="detail-inquiry-header">
+        <h3>신고하기</h3>
+        <button type="button" class="detail-inquiry-close" @click="$emit('close')">×</button>
+      </div>
+
+      <div class="detail-inquiry-summary">
+        <img :src="assets.listWatchImage" :alt="item.title" class="detail-inquiry-thumb" />
+        <div class="detail-inquiry-summary-copy">
+          <strong>{{ item.title }}</strong>
+          <span>현재 입찰가</span>
+          <em>{{ item.price }}원</em>
+        </div>
+      </div>
+
+      <div class="detail-report-fields">
+        <div class="detail-report-field">
+          <span>신고 유형 <em>*</em></span>
+          <div class="detail-report-options">
+            <button
+              v-for="type in reportTypes"
+              :key="type"
+              type="button"
+              class="detail-report-option"
+              :class="{ 'is-selected': form.type === type }"
+              @click="form.type = type"
+            >
+              <span class="detail-report-radio" />
+              <span>{{ type }}</span>
+            </button>
+          </div>
+        </div>
+
+        <label class="detail-report-field">
+          <span>신고 내용 <em>*</em></span>
+          <textarea
+            v-model="form.detail"
+            class="detail-report-textarea"
+            placeholder="신고 사유에 대한 구체적인 내용을 작성해주세요."
+          />
+        </label>
+      </div>
+
+      <button type="button" class="detail-report-submit" @click="$emit('submit')">
+        신고하기
+      </button>
+    </section>
+  </div>
+</template>

--- a/src/components/auction-detail/SellerCardSection.vue
+++ b/src/components/auction-detail/SellerCardSection.vue
@@ -1,0 +1,25 @@
+<script setup>
+defineProps({
+  item: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['open-inquiry', 'open-seller'])
+</script>
+
+<template>
+  <div class="seller-card">
+    <div class="seller-meta">
+      <div class="seller-avatar"></div>
+      <div class="seller-info">
+        <button type="button" class="seller-name-button" @click="$emit('open-seller')">
+          {{ item.seller }}
+        </button>
+        <span class="seller-grade">{{ item.sellerGrade }}</span>
+      </div>
+    </div>
+    <button type="button" class="seller-button" @click="$emit('open-inquiry')">문의 하기</button>
+  </div>
+</template>

--- a/src/components/auction-detail/SellerProfileModal.vue
+++ b/src/components/auction-detail/SellerProfileModal.vue
@@ -1,0 +1,94 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+  sellerProfile: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['close'])
+</script>
+
+<template>
+  <div class="detail-inquiry-overlay" @click.self="$emit('close')">
+    <section class="detail-seller-modal">
+      <div class="detail-seller-modal-header">
+        <button type="button" class="detail-inquiry-close" @click="$emit('close')">×</button>
+      </div>
+
+      <div class="detail-seller-profile">
+        <img :src="sellerProfile.avatar" :alt="item.seller" class="detail-seller-avatar" />
+        <div class="detail-seller-copy">
+          <div class="detail-seller-name-row">
+            <img :src="sellerProfile.badge" alt="" class="detail-seller-badge" />
+            <strong>{{ item.seller }}</strong>
+          </div>
+
+          <div class="detail-seller-meta-row">
+            <div class="detail-seller-rating">
+              <span
+                v-for="starIndex in 5"
+                :key="`seller-star-${starIndex}`"
+                class="detail-seller-star"
+              >
+                {{ starIndex <= Math.round(Number(sellerProfile.rating)) ? '★' : '☆' }}
+              </span>
+              <span class="detail-seller-rating-value">{{ sellerProfile.rating }}</span>
+              <span class="detail-seller-review-count">(리뷰 {{ sellerProfile.reviewCount }})</span>
+            </div>
+
+            <div class="detail-seller-joined">가입일: {{ sellerProfile.joinedAt }}</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="detail-seller-stats">
+        <article
+          v-for="stat in sellerProfile.stats"
+          :key="stat.label"
+          class="detail-seller-stat-card"
+        >
+          <span>{{ stat.label }}</span>
+          <strong>{{ stat.value }}</strong>
+        </article>
+      </div>
+
+      <div class="detail-seller-reviews">
+        <h3>구매자 리뷰 ({{ sellerProfile.reviewCount }})</h3>
+
+        <article
+          v-for="review in sellerProfile.reviews"
+          :key="`${review.author}-${review.date}`"
+          class="detail-seller-review"
+        >
+          <div class="detail-seller-review-top">
+            <div>
+              <strong>{{ review.author }}</strong>
+              <span>{{ review.date }}</span>
+            </div>
+            <div class="detail-seller-review-stars">
+              <span
+                v-for="starIndex in 5"
+                :key="`${review.author}-star-${starIndex}`"
+                class="detail-seller-star"
+              >
+                {{ starIndex <= review.rating ? '★' : '☆' }}
+              </span>
+            </div>
+          </div>
+
+          <img :src="assets.listWatchImage" :alt="item.title" class="detail-seller-review-image" />
+          <p>{{ review.content }}</p>
+        </article>
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/components/auction-detail/SellerProfileModal.vue
+++ b/src/components/auction-detail/SellerProfileModal.vue
@@ -1,4 +1,6 @@
 <script setup>
+import BaseModal from '../shared/BaseModal.vue'
+
 defineProps({
   assets: {
     type: Object,
@@ -18,11 +20,12 @@ defineEmits(['close'])
 </script>
 
 <template>
-  <div class="detail-inquiry-overlay" @click.self="$emit('close')">
-    <section class="detail-seller-modal">
+  <BaseModal panel-class="detail-seller-modal" @close="$emit('close')">
+    <template #header>
       <div class="detail-seller-modal-header">
         <button type="button" class="detail-inquiry-close" @click="$emit('close')">×</button>
       </div>
+    </template>
 
       <div class="detail-seller-profile">
         <img :src="sellerProfile.avatar" :alt="item.seller" class="detail-seller-avatar" />
@@ -89,6 +92,5 @@ defineEmits(['close'])
           <p>{{ review.content }}</p>
         </article>
       </div>
-    </section>
-  </div>
+  </BaseModal>
 </template>

--- a/src/components/inspection/InspectionDetailModal.vue
+++ b/src/components/inspection/InspectionDetailModal.vue
@@ -1,0 +1,89 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  badgeClass: {
+    type: Function,
+    required: true,
+  },
+  detailActionLabel: {
+    type: Function,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['close', 'handle-action'])
+</script>
+
+<template>
+  <div class="inspection-status-overlay" @click.self="$emit('close')">
+    <section class="inspection-status-modal">
+      <button type="button" class="inspection-status-close" @click="$emit('close')">
+        ×
+      </button>
+
+      <div class="inspection-status-grid">
+        <div class="inspection-status-image-card">
+          <img :src="assets.listWatchImage" :alt="item.title" class="inspection-status-image" />
+        </div>
+
+        <div class="inspection-status-summary">
+          <p class="inspection-status-category">럭셔리 &gt; 시계 &gt; 남성용 시계</p>
+          <span class="inspection-badge" :class="badgeClass(item.status)">
+            {{ item.status }}
+          </span>
+          <h3>{{ item.title }}</h3>
+
+          <div class="inspection-status-meta">
+            <div>
+              <span>브랜드</span>
+              <strong>{{ item.brand }}</strong>
+            </div>
+            <div>
+              <span>검수일</span>
+              <strong>{{ item.inspectionDate }}</strong>
+            </div>
+            <div>
+              <span>검수 등급</span>
+              <strong class="is-grade">{{ item.inspectionGrade }}</strong>
+            </div>
+          </div>
+        </div>
+
+        <div class="inspection-status-section">
+          <h4>상품 설명</h4>
+          <p>{{ item.description }}</p>
+        </div>
+
+        <div class="inspection-status-section">
+          <h4>배송 정보</h4>
+
+          <div v-if="item.status === '검수 대기'" class="inspection-status-alert">
+            <span class="inspection-status-alert-icon">!</span>
+            <p>배송 정보를 등록해주세요</p>
+          </div>
+
+          <template v-else>
+            <p>우체국 택배</p>
+            <p>1928391823798</p>
+          </template>
+        </div>
+      </div>
+
+      <div class="inspection-status-actions">
+        <button type="button" class="register-secondary-button" @click="$emit('close')">
+          {{ item.status === '검수 대기' ? '신청 취소' : '닫기' }}
+        </button>
+        <button type="button" class="register-primary-button" @click="$emit('handle-action')">
+          {{ detailActionLabel(item.status) }}
+        </button>
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/components/inspection/InspectionDetailModal.vue
+++ b/src/components/inspection/InspectionDetailModal.vue
@@ -1,4 +1,6 @@
 <script setup>
+import BaseModal from '../shared/BaseModal.vue'
+
 defineProps({
   assets: {
     type: Object,
@@ -22,13 +24,14 @@ defineEmits(['close', 'handle-action'])
 </script>
 
 <template>
-  <div class="inspection-status-overlay" @click.self="$emit('close')">
-    <section class="inspection-status-modal">
+  <BaseModal overlay-class="inspection-status-overlay" panel-class="inspection-status-modal" @close="$emit('close')">
+    <template #header>
       <button type="button" class="inspection-status-close" @click="$emit('close')">
         ×
       </button>
+    </template>
 
-      <div class="inspection-status-grid">
+    <div class="inspection-status-grid">
         <div class="inspection-status-image-card">
           <img :src="assets.listWatchImage" :alt="item.title" class="inspection-status-image" />
         </div>
@@ -84,6 +87,5 @@ defineEmits(['close', 'handle-action'])
           {{ detailActionLabel(item.status) }}
         </button>
       </div>
-    </section>
-  </div>
+  </BaseModal>
 </template>

--- a/src/components/inspection/InspectionProductGrid.vue
+++ b/src/components/inspection/InspectionProductGrid.vue
@@ -1,0 +1,47 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  badgeClass: {
+    type: Function,
+    required: true,
+  },
+  items: {
+    type: Array,
+    required: true,
+  },
+})
+
+defineEmits(['open-detail'])
+</script>
+
+<template>
+  <div class="inspection-card-grid">
+    <article
+      v-for="(item, index) in items"
+      :key="`${item.title}-${index}`"
+      class="inspection-product-card"
+      @click="$emit('open-detail', item)"
+    >
+      <div class="inspection-product-image-wrap">
+        <img :src="assets.listWatchImage" :alt="item.title" class="inspection-product-image" />
+        <span class="inspection-badge" :class="badgeClass(item.status)">
+          {{ item.status }}
+        </span>
+      </div>
+
+      <div class="inspection-product-body">
+        <h3>{{ item.title }}</h3>
+        <div class="inspection-product-meta">
+          <div>
+            <span>검수 등급</span>
+            <strong>{{ item.inspectionGrade }}</strong>
+          </div>
+          <span>{{ item.inspectionDate }}</span>
+        </div>
+      </div>
+    </article>
+  </div>
+</template>

--- a/src/components/inspection/InspectionShippingModal.vue
+++ b/src/components/inspection/InspectionShippingModal.vue
@@ -1,4 +1,6 @@
 <script setup>
+import BaseModal from '../shared/BaseModal.vue'
+
 defineProps({
   form: {
     type: Object,
@@ -10,12 +12,17 @@ defineEmits(['close', 'submit'])
 </script>
 
 <template>
-  <div class="inspection-shipping-overlay" @click.self="$emit('close')">
-    <section class="inspection-shipping-modal">
+  <BaseModal
+    overlay-class="inspection-shipping-overlay"
+    panel-class="inspection-shipping-modal"
+    @close="$emit('close')"
+  >
+    <template #header>
       <div class="inspection-shipping-header">
         <h3>배송 정보 등록</h3>
         <button type="button" class="inspection-shipping-close" @click="$emit('close')">×</button>
       </div>
+    </template>
 
       <div class="inspection-shipping-form">
         <label class="inspection-shipping-field is-small">
@@ -43,6 +50,5 @@ defineEmits(['close', 'submit'])
       <button type="button" class="inspection-shipping-submit" @click="$emit('submit')">
         등록하기
       </button>
-    </section>
-  </div>
+  </BaseModal>
 </template>

--- a/src/components/inspection/InspectionShippingModal.vue
+++ b/src/components/inspection/InspectionShippingModal.vue
@@ -1,0 +1,48 @@
+<script setup>
+defineProps({
+  form: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['close', 'submit'])
+</script>
+
+<template>
+  <div class="inspection-shipping-overlay" @click.self="$emit('close')">
+    <section class="inspection-shipping-modal">
+      <div class="inspection-shipping-header">
+        <h3>배송 정보 등록</h3>
+        <button type="button" class="inspection-shipping-close" @click="$emit('close')">×</button>
+      </div>
+
+      <div class="inspection-shipping-form">
+        <label class="inspection-shipping-field is-small">
+          <span>택배사 <em>*</em></span>
+          <div class="register-select-wrap">
+            <select v-model="form.company">
+              <option value="" disabled>선택</option>
+              <option value="우체국 택배">우체국 택배</option>
+              <option value="CJ대한통운">CJ대한통운</option>
+              <option value="한진택배">한진택배</option>
+            </select>
+          </div>
+        </label>
+
+        <label class="inspection-shipping-field">
+          <span>송장 번호 <em>*</em></span>
+          <input
+            v-model="form.invoiceNumber"
+            type="text"
+            placeholder="송장 번호를 입력해 주세요."
+          />
+        </label>
+      </div>
+
+      <button type="button" class="inspection-shipping-submit" @click="$emit('submit')">
+        등록하기
+      </button>
+    </section>
+  </div>
+</template>

--- a/src/components/inspection/InspectionSummaryGrid.vue
+++ b/src/components/inspection/InspectionSummaryGrid.vue
@@ -1,0 +1,30 @@
+<script setup>
+defineProps({
+  summary: {
+    type: Array,
+    required: true,
+  },
+  summaryIcon: {
+    type: Function,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <div class="inspection-summary-grid">
+    <article
+      v-for="item in summary"
+      :key="item.label"
+      class="inspection-summary-card"
+    >
+      <div class="inspection-summary-icon" :class="`is-${item.tone}`">
+        {{ summaryIcon(item.label) }}
+      </div>
+      <div class="inspection-summary-copy">
+        <span>{{ item.label }}</span>
+        <strong>{{ item.value }}</strong>
+      </div>
+    </article>
+  </div>
+</template>

--- a/src/components/inspection/InspectionToolbar.vue
+++ b/src/components/inspection/InspectionToolbar.vue
@@ -1,0 +1,40 @@
+<script setup>
+defineProps({
+  activeFilter: {
+    type: String,
+    required: true,
+  },
+  assets: {
+    type: Object,
+    required: true,
+  },
+  filterOptions: {
+    type: Array,
+    required: true,
+  },
+})
+
+defineEmits(['update:activeFilter'])
+</script>
+
+<template>
+  <div class="inspection-toolbar">
+    <div class="inspection-filters">
+      <button
+        v-for="filter in filterOptions"
+        :key="filter"
+        type="button"
+        class="inspection-filter"
+        :class="{ 'is-active': activeFilter === filter }"
+        @click="$emit('update:activeFilter', filter)"
+      >
+        {{ filter }}
+      </button>
+    </div>
+
+    <div class="inspection-search">
+      <img :src="assets.listSearchIcon" alt="" class="inspection-search-icon" />
+      <span>상품명, 브랜드 검색</span>
+    </div>
+  </div>
+</template>

--- a/src/components/mypage/MyPageBidSection.vue
+++ b/src/components/mypage/MyPageBidSection.vue
@@ -1,0 +1,50 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  items: {
+    type: Array,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <section class="mypage-section">
+    <div class="mypage-section-header">
+      <h3>입찰 내역</h3>
+      <button type="button">View All</button>
+    </div>
+
+    <div class="mypage-bid-list">
+      <article
+        v-for="(item, index) in items"
+        :key="`${item.title}-${index}`"
+        class="mypage-bid-card"
+      >
+        <img :src="assets.mypageProductImage" :alt="item.title" class="mypage-bid-image" />
+
+        <div class="mypage-bid-content">
+          <div class="mypage-bid-copy">
+            <span class="mypage-chip is-auction">{{ item.status }}</span>
+            <h4>{{ item.title }}</h4>
+            <div class="mypage-time">
+              <img :src="assets.clockIcon" alt="" />
+              <span>{{ item.time }}</span>
+            </div>
+          </div>
+
+          <div class="mypage-bid-prices">
+            <span>현재가</span>
+            <strong>{{ item.currentPrice }}</strong>
+            <span>내 입찰가</span>
+            <strong>{{ item.myBidPrice }}</strong>
+            <span>{{ item.date }}</span>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>

--- a/src/components/mypage/MyPageBidSection.vue
+++ b/src/components/mypage/MyPageBidSection.vue
@@ -1,4 +1,6 @@
 <script setup>
+import SectionHeader from '../shared/SectionHeader.vue'
+
 defineProps({
   assets: {
     type: Object,
@@ -13,10 +15,11 @@ defineProps({
 
 <template>
   <section class="mypage-section">
-    <div class="mypage-section-header">
-      <h3>입찰 내역</h3>
-      <button type="button">View All</button>
-    </div>
+    <SectionHeader
+      title="입찰 내역"
+      action-label="View All"
+      wrapper-class="mypage-section-header"
+    />
 
     <div class="mypage-bid-list">
       <article

--- a/src/components/mypage/MyPageProfileCard.vue
+++ b/src/components/mypage/MyPageProfileCard.vue
@@ -1,0 +1,31 @@
+<script setup>
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  profile: {
+    type: Object,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <section class="mypage-profile-card">
+    <div class="mypage-profile-row">
+      <div class="mypage-profile-user">
+        <img :src="assets.mypageAvatar" :alt="profile.seller" class="mypage-avatar" />
+        <div class="mypage-user-copy">
+          <img :src="assets.mypageBadge" alt="" class="mypage-badge" />
+          <strong>{{ profile.seller }}</strong>
+        </div>
+      </div>
+    </div>
+
+    <div class="mypage-points-block">
+      <span>보유 포인트</span>
+      <strong>{{ profile.points }}</strong>
+    </div>
+  </section>
+</template>

--- a/src/components/mypage/MyPagePurchaseSection.vue
+++ b/src/components/mypage/MyPagePurchaseSection.vue
@@ -1,4 +1,6 @@
 <script setup>
+import SectionHeader from '../shared/SectionHeader.vue'
+
 defineProps({
   items: {
     type: Array,
@@ -13,10 +15,11 @@ defineProps({
 
 <template>
   <section class="mypage-section">
-    <div class="mypage-section-header">
-      <h3>진행 중 구매 현황</h3>
-      <button type="button">View All</button>
-    </div>
+    <SectionHeader
+      title="진행 중 구매 현황"
+      action-label="View All"
+      wrapper-class="mypage-section-header"
+    />
 
     <div class="mypage-purchase-list">
       <article

--- a/src/components/mypage/MyPagePurchaseSection.vue
+++ b/src/components/mypage/MyPagePurchaseSection.vue
@@ -1,0 +1,40 @@
+<script setup>
+defineProps({
+  items: {
+    type: Array,
+    required: true,
+  },
+  purchaseBadgeClass: {
+    type: Function,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <section class="mypage-section">
+    <div class="mypage-section-header">
+      <h3>진행 중 구매 현황</h3>
+      <button type="button">View All</button>
+    </div>
+
+    <div class="mypage-purchase-list">
+      <article
+        v-for="(item, index) in items"
+        :key="`${item.title}-${index}`"
+        class="mypage-purchase-card"
+      >
+        <div class="mypage-purchase-copy">
+          <span class="mypage-chip" :class="purchaseBadgeClass(item.status)">{{ item.status }}</span>
+          <h4>{{ item.title }}</h4>
+          <p>구매자: {{ item.buyer }}</p>
+        </div>
+
+        <div class="mypage-purchase-price">
+          <strong>{{ item.price }}</strong>
+          <span>{{ item.date }}</span>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>

--- a/src/components/register/AuctionSetupForm.vue
+++ b/src/components/register/AuctionSetupForm.vue
@@ -1,0 +1,160 @@
+<script setup>
+defineProps({
+  auctionForm: {
+    type: Object,
+    required: true,
+  },
+  bidUnitOptions: {
+    type: Array,
+    required: true,
+  },
+  durationOptions: {
+    type: Array,
+    required: true,
+  },
+  selectedBidUnit: {
+    type: String,
+    required: true,
+  },
+  selectedDuration: {
+    type: String,
+    required: true,
+  },
+  submitted: {
+    type: Boolean,
+    required: true,
+  },
+  successMessage: {
+    type: String,
+    required: true,
+  },
+})
+
+defineEmits(['cancel', 'select-bid-unit', 'select-duration', 'submit', 'toggle-field'])
+</script>
+
+<template>
+  <section class="register-form-card register-auction-card">
+    <div class="auction-settings">
+      <div class="auction-toggle-grid">
+        <article class="auction-toggle-card">
+          <div class="auction-toggle-copy">
+            <div class="auction-toggle-icon is-extend">↻</div>
+            <div>
+              <strong>연장 경매</strong>
+              <p>종료 직전 입찰 시 시간 연장</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            class="auction-switch"
+            :class="{ 'is-on': auctionForm.extendAuction }"
+            @click="$emit('toggle-field', 'extendAuction')"
+          >
+            <span />
+          </button>
+        </article>
+
+        <article class="auction-toggle-card">
+          <div class="auction-toggle-copy">
+            <div class="auction-toggle-icon is-timedeal">⚡</div>
+            <div>
+              <strong>타임딜</strong>
+              <p>단시간 내 고가가 낙찰 유도</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            class="auction-switch"
+            :class="[{ 'is-on': auctionForm.timeDeal }, 'is-danger']"
+            @click="$emit('toggle-field', 'timeDeal')"
+          >
+            <span />
+          </button>
+        </article>
+      </div>
+
+      <div class="auction-field-grid">
+        <label class="register-field">
+          <span class="register-label">경매 시작가 <span>*</span></span>
+          <div class="auction-money-field">
+            <input v-model="auctionForm.startPrice" type="number" placeholder="0" />
+            <span>원</span>
+          </div>
+        </label>
+
+        <label class="register-field">
+          <span class="register-label">즉시 구매가</span>
+          <div class="auction-money-field">
+            <input v-model="auctionForm.buyNowPrice" type="number" placeholder="0" />
+            <span>원</span>
+          </div>
+        </label>
+      </div>
+
+      <div class="auction-option-section">
+        <span class="register-label">입찰 단위 <span>*</span></span>
+        <div class="auction-chip-row">
+          <button
+            v-for="option in bidUnitOptions"
+            :key="option"
+            type="button"
+            class="auction-chip"
+            :class="{ 'is-selected': selectedBidUnit === option }"
+            @click="$emit('select-bid-unit', option)"
+          >
+            {{ option }}
+          </button>
+        </div>
+      </div>
+
+      <div class="auction-option-section">
+        <span class="register-label">경매 기간 <span>*</span></span>
+
+        <div class="auction-date-grid">
+          <div class="auction-date-card">
+            <span class="auction-date-label">시작 일시</span>
+            <div class="auction-date-value-row">
+              <div class="auction-date-value">🗓 {{ auctionForm.startDate }}</div>
+              <div class="auction-date-value">🕒 {{ auctionForm.startTime }}</div>
+            </div>
+          </div>
+
+          <div class="auction-date-card">
+            <span class="auction-date-label">종료 일시</span>
+            <div class="auction-date-value-row">
+              <div class="auction-date-value">🗓 {{ auctionForm.endDate }}</div>
+              <div class="auction-date-value">🕒 {{ auctionForm.endTime }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="auction-chip-row is-duration">
+          <button
+            v-for="option in durationOptions"
+            :key="option"
+            type="button"
+            class="auction-chip"
+            :class="{ 'is-selected': selectedDuration === option }"
+            @click="$emit('select-duration', option)"
+          >
+            {{ option }}
+          </button>
+        </div>
+      </div>
+
+      <div v-if="submitted" class="register-success-banner">
+        {{ successMessage }}
+      </div>
+
+      <div class="register-actions">
+        <button type="button" class="register-secondary-button" @click="$emit('cancel')">
+          취소
+        </button>
+        <button type="button" class="register-primary-button" @click="$emit('submit')">
+          확인
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/register/InspectionDetailModal.vue
+++ b/src/components/register/InspectionDetailModal.vue
@@ -1,0 +1,71 @@
+<script setup>
+defineProps({
+  inspectionProductImage: {
+    type: String,
+    required: true,
+  },
+  item: {
+    type: Object,
+    required: true,
+  },
+})
+
+defineEmits(['close', 'start-auction'])
+</script>
+
+<template>
+  <div class="inspection-detail-overlay" @click.self="$emit('close')">
+    <section class="inspection-detail-modal">
+      <button type="button" class="inspection-detail-close" @click="$emit('close')">
+        ×
+      </button>
+
+      <div class="inspection-detail-grid">
+        <div class="inspection-detail-image-card">
+          <img :src="inspectionProductImage" :alt="item.title" class="inspection-detail-image" />
+        </div>
+
+        <div class="inspection-detail-summary">
+          <p class="inspection-detail-category">럭셔리 &gt; 시계 &gt; 남성용 시계</p>
+          <span class="inspection-badge is-passed">검수 통과</span>
+          <h3>{{ item.title }}</h3>
+
+          <div class="inspection-detail-meta">
+            <div>
+              <span>브랜드</span>
+              <strong>{{ item.brand }}</strong>
+            </div>
+            <div>
+              <span>검수일</span>
+              <strong>{{ item.inspectionDate }}</strong>
+            </div>
+            <div>
+              <span>검수 등급</span>
+              <strong class="is-grade">{{ item.inspectionGrade }}</strong>
+            </div>
+          </div>
+        </div>
+
+        <div class="inspection-detail-section">
+          <h4>상품 설명</h4>
+          <p>{{ item.description }}</p>
+        </div>
+
+        <div class="inspection-detail-section">
+          <h4>배송 정보</h4>
+          <p>우체국 택배</p>
+          <p>1928391823798</p>
+        </div>
+      </div>
+
+      <div class="inspection-detail-actions">
+        <button type="button" class="register-secondary-button" @click="$emit('close')">
+          반환 신청
+        </button>
+        <button type="button" class="register-primary-button" @click="$emit('start-auction')">
+          경매 등록
+        </button>
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/components/register/InspectionPickStep.vue
+++ b/src/components/register/InspectionPickStep.vue
@@ -1,0 +1,83 @@
+<script setup>
+import InspectionDetailModal from './InspectionDetailModal.vue'
+
+defineProps({
+  assets: {
+    type: Object,
+    required: true,
+  },
+  inspectionPickItems: {
+    type: Array,
+    required: true,
+  },
+  inspectionProductImage: {
+    type: String,
+    required: true,
+  },
+  isInspectionDetailOpen: {
+    type: Boolean,
+    required: true,
+  },
+  selectedInspectionId: {
+    type: Number,
+    required: true,
+  },
+  selectedInspectionItem: {
+    type: Object,
+    default: null,
+  },
+})
+
+defineEmits(['close-detail', 'select-item', 'start-auction'])
+</script>
+
+<template>
+  <section class="register-form-card register-inspection-pick-card">
+    <div class="inspection-toolbar register-inspection-toolbar">
+      <div class="inspection-search">
+        <img :src="assets.listSearchIcon" alt="" class="inspection-search-icon" />
+        <span>상품명, 브랜드 검색</span>
+      </div>
+    </div>
+
+    <div class="inspection-card-grid register-inspection-grid">
+      <article
+        v-for="item in inspectionPickItems"
+        :key="`${item.title}-${item.displayId}`"
+        class="inspection-product-card register-inspection-card"
+        :class="{ 'is-selected': selectedInspectionId === item.displayId }"
+        @click="$emit('select-item', item.displayId)"
+      >
+        <div class="inspection-product-image-wrap">
+          <img :src="inspectionProductImage" :alt="item.title" class="inspection-product-image" />
+          <span class="inspection-badge is-passed">검수 통과</span>
+        </div>
+
+        <div class="inspection-product-body">
+          <h3>{{ item.title }}</h3>
+          <div class="inspection-product-meta">
+            <div>
+              <span>검수 등급</span>
+              <strong>{{ item.inspectionGrade }}</strong>
+            </div>
+            <span>{{ item.inspectionDate }}</span>
+          </div>
+        </div>
+      </article>
+
+      <article class="register-empty-card">
+        <div class="register-empty-icon">+</div>
+        <strong>상품이 없으신가요?</strong>
+        <p>신규 사전 검수 상품을 등록해보세요.</p>
+      </article>
+    </div>
+
+    <InspectionDetailModal
+      v-if="isInspectionDetailOpen && selectedInspectionItem"
+      :inspection-product-image="inspectionProductImage"
+      :item="selectedInspectionItem"
+      @close="$emit('close-detail')"
+      @start-auction="$emit('start-auction')"
+    />
+  </section>
+</template>

--- a/src/components/register/RegisterMethodSelect.vue
+++ b/src/components/register/RegisterMethodSelect.vue
@@ -1,0 +1,47 @@
+<script setup>
+defineProps({
+  methods: {
+    type: Array,
+    required: true,
+  },
+})
+
+defineEmits(['select-mode'])
+</script>
+
+<template>
+  <section class="register-method-grid">
+    <article
+      v-for="method in methods"
+      :key="method.title"
+      class="register-method-card"
+      :class="method.cardClass"
+    >
+      <div class="register-method-icon-wrap">
+        <img :src="method.iconSrc" :alt="method.title" class="register-method-icon" />
+      </div>
+
+      <h3>{{ method.title }}</h3>
+
+      <ul class="register-method-points">
+        <li
+          v-for="point in method.points"
+          :key="point"
+          class="register-method-point"
+        >
+          <img :src="method.bulletSrc" alt="" class="register-method-bullet" />
+          <span>{{ point }}</span>
+        </li>
+      </ul>
+
+      <button
+        type="button"
+        class="register-method-button"
+        :class="method.buttonClass"
+        @click="$emit('select-mode', method.key)"
+      >
+        {{ method.buttonLabel }}
+      </button>
+    </article>
+  </section>
+</template>

--- a/src/components/register/RegisterProductForm.vue
+++ b/src/components/register/RegisterProductForm.vue
@@ -1,0 +1,158 @@
+<script setup>
+import { ref } from 'vue'
+
+defineProps({
+  currentMode: {
+    type: String,
+    required: true,
+  },
+  form: {
+    type: Object,
+    required: true,
+  },
+  submitted: {
+    type: Boolean,
+    required: true,
+  },
+  successMessage: {
+    type: String,
+    required: true,
+  },
+  thumbnailPlaceholders: {
+    type: Number,
+    required: true,
+  },
+  uploadedImages: {
+    type: Array,
+    required: true,
+  },
+})
+
+defineEmits(['cancel', 'files-selected', 'remove-image', 'submit'])
+
+const fileInput = ref(null)
+
+function openFilePicker() {
+  fileInput.value?.click()
+}
+</script>
+
+<template>
+  <section class="register-form-card">
+    <div class="register-form-grid">
+      <div class="register-upload-column">
+        <label class="register-label">상품 이미지 <span>*</span></label>
+        <input
+          ref="fileInput"
+          class="register-hidden-input"
+          type="file"
+          accept="image/*"
+          multiple
+          @change="$emit('files-selected', $event)"
+        />
+
+        <button type="button" class="register-upload-box" @click="openFilePicker">
+          <img
+            v-if="uploadedImages[0]"
+            :src="uploadedImages[0].previewUrl"
+            alt=""
+            class="register-main-preview"
+          />
+          <template v-else>
+            <div class="register-upload-placeholder">
+              <div class="register-upload-icon">+</div>
+              <span>이미지 업로드</span>
+            </div>
+          </template>
+        </button>
+
+        <div class="register-thumb-row">
+          <button
+            v-for="(image, index) in uploadedImages.slice(1)"
+            :key="`${image.name}-${index}`"
+            type="button"
+            class="register-thumb register-thumb-image"
+            @click="$emit('remove-image', index + 1)"
+          >
+            <img :src="image.previewUrl" :alt="image.name" />
+          </button>
+          <div
+            v-for="slot in thumbnailPlaceholders"
+            :key="`empty-${slot}`"
+            class="register-thumb"
+          />
+        </div>
+
+        <p class="register-helper-text">최대 20MB까지 업로드 가능</p>
+      </div>
+
+      <div class="register-fields-column">
+        <label class="register-field">
+          <span class="register-label">상품명 <span>*</span></span>
+          <input
+            v-model="form.name"
+            type="text"
+            :placeholder="currentMode === 'inspection' ? '상품명을 입력해 주세요.' : '상품명을 입력해주세요.'"
+          />
+        </label>
+
+        <label class="register-field">
+          <span class="register-label">카테고리 <span>*</span></span>
+          <div class="register-select-wrap">
+            <select v-model="form.category">
+              <option value="" disabled>
+                {{ currentMode === 'inspection' ? '카테고리를 선택해 주세요.' : '카테고리를 선택해주세요.' }}
+              </option>
+              <option value="watch">시계</option>
+              <option value="bag">가방</option>
+              <option value="shoes">신발</option>
+            </select>
+          </div>
+        </label>
+
+        <label v-if="currentMode === 'direct'" class="register-field">
+          <span class="register-label">상품 상태 <span>*</span></span>
+          <div class="register-select-wrap">
+            <select v-model="form.condition">
+              <option value="" disabled>상품의 상태를 선택해주세요.</option>
+              <option value="최상">최상</option>
+              <option value="상">상</option>
+              <option value="중">중</option>
+              <option value="하">하</option>
+            </select>
+          </div>
+        </label>
+
+        <label class="register-field">
+          <span class="register-label">브랜드</span>
+          <input
+            v-model="form.brand"
+            type="text"
+            :placeholder="currentMode === 'inspection' ? '브랜드를 입력해 주세요.' : '브랜드를 입력해주세요.'"
+          />
+        </label>
+
+        <label class="register-field">
+          <span class="register-label">상세 설명 <span>*</span></span>
+          <textarea
+            v-model="form.description"
+            placeholder="구매 시기, 보증서 유무, 하자 여부 등 상세한 내용을 입력해주세요."
+          />
+        </label>
+      </div>
+    </div>
+
+    <div v-if="submitted" class="register-success-banner">
+      {{ successMessage }}
+    </div>
+
+    <div class="register-actions">
+      <button type="button" class="register-secondary-button" @click="$emit('cancel')">
+        취소
+      </button>
+      <button type="button" class="register-primary-button" @click="$emit('submit')">
+        확인
+      </button>
+    </div>
+  </section>
+</template>

--- a/src/components/register/RegisterStepper.vue
+++ b/src/components/register/RegisterStepper.vue
@@ -1,0 +1,26 @@
+<script setup>
+defineProps({
+  firstStepLabel: {
+    type: String,
+    required: true,
+  },
+  isAuctionStep: {
+    type: Boolean,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <div class="register-stepper">
+    <div class="register-step" :class="{ 'is-active': !isAuctionStep }">
+      <span class="register-step-index" :class="{ 'is-muted': isAuctionStep }">1</span>
+      <span>{{ firstStepLabel }}</span>
+    </div>
+    <span class="register-step-line" />
+    <div class="register-step" :class="{ 'is-active': isAuctionStep }">
+      <span class="register-step-index" :class="{ 'is-muted': !isAuctionStep }">2</span>
+      <span>경매 등록</span>
+    </div>
+  </div>
+</template>

--- a/src/components/shared/BaseModal.vue
+++ b/src/components/shared/BaseModal.vue
@@ -1,0 +1,37 @@
+<script setup>
+defineProps({
+  overlayClass: {
+    type: String,
+    default: 'detail-inquiry-overlay',
+  },
+  panelClass: {
+    type: String,
+    required: true,
+  },
+  title: {
+    type: String,
+    default: '',
+  },
+  closeClass: {
+    type: String,
+    default: 'detail-inquiry-close',
+  },
+})
+
+defineEmits(['close'])
+</script>
+
+<template>
+  <div :class="overlayClass" @click.self="$emit('close')">
+    <section :class="panelClass">
+      <slot name="header">
+        <div v-if="title" class="detail-inquiry-header">
+          <h3>{{ title }}</h3>
+          <button type="button" :class="closeClass" @click="$emit('close')">×</button>
+        </div>
+      </slot>
+
+      <slot />
+    </section>
+  </div>
+</template>

--- a/src/components/shared/SectionHeader.vue
+++ b/src/components/shared/SectionHeader.vue
@@ -1,0 +1,42 @@
+<script setup>
+defineProps({
+  actionClass: {
+    type: String,
+    default: '',
+  },
+  actionLabel: {
+    type: String,
+    default: '',
+  },
+  title: {
+    type: String,
+    required: true,
+  },
+  titleClass: {
+    type: String,
+    default: '',
+  },
+  wrapperClass: {
+    type: String,
+    required: true,
+  },
+})
+
+defineEmits(['action'])
+</script>
+
+<template>
+  <div :class="wrapperClass">
+    <component :is="titleClass ? 'div' : 'h3'" :class="titleClass || undefined">
+      {{ title }}
+    </component>
+    <button
+      v-if="actionLabel"
+      type="button"
+      :class="actionClass || undefined"
+      @click="$emit('action')"
+    >
+      {{ actionLabel }}
+    </button>
+  </div>
+</template>

--- a/src/composables/useAuctionDetailState.js
+++ b/src/composables/useAuctionDetailState.js
@@ -1,0 +1,190 @@
+import { computed, ref } from 'vue'
+
+const reportTypes = [
+  '위조품 / 가짜 상품',
+  '허위 / 과장 정보',
+  '부적절한 콘텐츠',
+  '중복 등록',
+  '도난물 의심',
+  '기타',
+]
+
+const bidHistoryRows = [
+  '1번 입찰자',
+  '2번 입찰자',
+  '3번 입찰자',
+  '4번 입찰자',
+  '5번 입찰자',
+  '6번 입찰자',
+  '1번 입찰자',
+  '2번 입찰자',
+  '2번 입찰자',
+  '2번 입찰자',
+  '7번 입찰자',
+  '8번 입찰자',
+  '1번 입찰자',
+  '10번 입찰자',
+].map((bidder) => ({
+  bidder,
+  amount: '***원',
+  date: '20xx/xx/xx xx:xx:xx.xx',
+}))
+
+const sellerProfile = {
+  avatar: 'https://www.figma.com/api/mcp/asset/1a84177d-d7c8-4353-8a50-20c14d87fbe5',
+  badge: 'https://www.figma.com/api/mcp/asset/81111f1e-47ca-4819-bcc5-08161ec6a90c',
+  rating: '4.8',
+  reviewCount: 100,
+  joinedAt: '2022. 03. 15',
+  stats: [
+    { label: '총 판매 건수', value: '1,000' },
+    { label: '판매 취소', value: '3' },
+    { label: '반품', value: '0' },
+    { label: '응답률', value: '98%' },
+  ],
+  reviews: [
+    {
+      author: 'Kim_D***',
+      date: '2023. 11. 24',
+      rating: 5,
+      content:
+        '포장이 정말 꼼꼼하게 잘 되어 왔습니다. 배송도 생각보다 훨씬 빠르고 물건 상태도 설명하신 것보다 더 좋네요. 믿고 거래할 수 있는 판매자입니다.',
+    },
+    {
+      author: 'Lee_H***',
+      date: '2023. 11. 20',
+      rating: 4,
+      content: '답변이 아주 빠르셔서 궁금한 점을 바로 해결할 수 있었습니다. 좋은 경매 감사합니다!',
+    },
+  ],
+}
+
+function parseAmount(value) {
+  return Number(String(value).replace(/[^\d]/g, '')) || 0
+}
+
+function formatAmount(value) {
+  return new Intl.NumberFormat('ko-KR').format(value)
+}
+
+export function useAuctionDetailState(item) {
+  const minimumBidAmount = computed(() => parseAmount(item.value.price) + parseAmount(item.value.bidUnit))
+  const buyNowAmount = computed(() => parseAmount(item.value.buyNowPrice))
+
+  const isSellerModalOpen = ref(false)
+  const isBidModalOpen = ref(false)
+  const isBidHistoryDrawerOpen = ref(false)
+  const isReportModalOpen = ref(false)
+  const isInquiryModalOpen = ref(false)
+
+  const reportForm = ref({
+    type: '기타',
+    detail: '',
+  })
+  const inquiryForm = ref({
+    isPrivate: true,
+    title: '',
+    content: '',
+  })
+  const bidAmount = ref('')
+
+  function openSellerModal() {
+    isSellerModalOpen.value = true
+  }
+
+  function closeSellerModal() {
+    isSellerModalOpen.value = false
+  }
+
+  function syncBidAmount(value = minimumBidAmount.value) {
+    bidAmount.value = formatAmount(value)
+  }
+
+  function openBidModal() {
+    isBidHistoryDrawerOpen.value = false
+    syncBidAmount()
+    isBidModalOpen.value = true
+  }
+
+  function closeBidModal() {
+    isBidModalOpen.value = false
+  }
+
+  function stepBid(direction) {
+    const nextAmount =
+      parseAmount(bidAmount.value || minimumBidAmount.value) + parseAmount(item.value.bidUnit) * direction
+    syncBidAmount(Math.max(minimumBidAmount.value, nextAmount))
+  }
+
+  function submitBid() {
+    isBidModalOpen.value = false
+  }
+
+  function buyNow() {
+    isBidModalOpen.value = false
+  }
+
+  function openBidHistoryDrawer() {
+    isBidHistoryDrawerOpen.value = true
+  }
+
+  function closeBidHistoryDrawer() {
+    isBidHistoryDrawerOpen.value = false
+  }
+
+  function openReportModal() {
+    isReportModalOpen.value = true
+  }
+
+  function closeReportModal() {
+    isReportModalOpen.value = false
+  }
+
+  function submitReport() {
+    isReportModalOpen.value = false
+  }
+
+  function openInquiryModal() {
+    isInquiryModalOpen.value = true
+  }
+
+  function closeInquiryModal() {
+    isInquiryModalOpen.value = false
+  }
+
+  function submitInquiry() {
+    isInquiryModalOpen.value = false
+  }
+
+  return {
+    bidAmount,
+    bidHistoryRows,
+    buyNowAmount,
+    closeBidHistoryDrawer,
+    closeBidModal,
+    closeInquiryModal,
+    closeReportModal,
+    closeSellerModal,
+    formatAmount,
+    inquiryForm,
+    isBidHistoryDrawerOpen,
+    isBidModalOpen,
+    isInquiryModalOpen,
+    isReportModalOpen,
+    isSellerModalOpen,
+    minimumBidAmount,
+    openBidHistoryDrawer,
+    openBidModal,
+    openInquiryModal,
+    openReportModal,
+    openSellerModal,
+    reportForm,
+    reportTypes,
+    sellerProfile,
+    stepBid,
+    submitBid,
+    submitInquiry,
+    submitReport,
+    buyNow,
+  }
+}

--- a/src/composables/useInspectionState.js
+++ b/src/composables/useInspectionState.js
@@ -1,0 +1,87 @@
+import { computed, ref } from 'vue'
+
+export function useInspectionState(items) {
+  const activeFilter = ref('전체')
+  const selectedItem = ref(null)
+  const isShippingModalOpen = ref(false)
+  const shippingForm = ref({
+    company: '',
+    invoiceNumber: '',
+  })
+
+  const filterOptions = ['전체', '검수 대기', '검수 통과', '검수 반려']
+
+  const filteredItems = computed(() => {
+    if (activeFilter.value === '전체') {
+      return items.value
+    }
+
+    return items.value.filter((item) => item.status === activeFilter.value)
+  })
+
+  function badgeClass(status) {
+    if (status === '검수 통과') return 'is-passed'
+    if (status === '검수 반려') return 'is-rejected'
+    if (status === '경매 진행 중') return 'is-auction'
+    return 'is-pending'
+  }
+
+  function summaryIcon(label) {
+    if (label === '총 검수 완료') return '✓'
+    if (label === '검수 대기') return '👜'
+    if (label === '검수 승인') return '⌛'
+    return '▣'
+  }
+
+  function openDetail(item) {
+    selectedItem.value = item
+  }
+
+  function closeDetail() {
+    selectedItem.value = null
+    isShippingModalOpen.value = false
+  }
+
+  function detailActionLabel(status) {
+    if (status === '검수 대기') return '배송 정보 등록'
+    if (status === '검수 통과') return '경매 등록'
+    if (status === '경매 진행 중') return '경매 상세 보기'
+    return '확인'
+  }
+
+  function handleDetailAction() {
+    if (!selectedItem.value) return
+
+    if (selectedItem.value.status === '검수 대기') {
+      isShippingModalOpen.value = true
+      return
+    }
+
+    closeDetail()
+  }
+
+  function closeShippingModal() {
+    isShippingModalOpen.value = false
+  }
+
+  function submitShippingInfo() {
+    isShippingModalOpen.value = false
+  }
+
+  return {
+    activeFilter,
+    badgeClass,
+    closeDetail,
+    closeShippingModal,
+    detailActionLabel,
+    filterOptions,
+    filteredItems,
+    handleDetailAction,
+    isShippingModalOpen,
+    openDetail,
+    selectedItem,
+    shippingForm,
+    submitShippingInfo,
+    summaryIcon,
+  }
+}

--- a/src/composables/useRegisterFlow.js
+++ b/src/composables/useRegisterFlow.js
@@ -1,0 +1,233 @@
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { inspectionItems } from '../data/marketplaceData'
+
+export function useRegisterFlow(initialMode) {
+  const allowedModes = ['select', 'inspection', 'inspection-pick', 'direct', 'direct-auction']
+  const currentMode = ref(allowedModes.includes(initialMode.value) ? initialMode.value : 'select')
+  const registrationType = ref(
+    initialMode.value === 'inspection' || initialMode.value === 'inspection-pick' ? 'inspection' : 'direct',
+  )
+  const submitted = ref(false)
+  const uploadedImages = ref([])
+  const selectedBidUnit = ref('10,000')
+  const selectedDuration = ref('5일')
+  const selectedInspectionId = ref(0)
+  const isInspectionDetailOpen = ref(false)
+
+  const form = ref({
+    name: '',
+    category: '',
+    brand: '',
+    condition: '',
+    description: '',
+  })
+
+  const auctionForm = ref({
+    extendAuction: true,
+    timeDeal: false,
+    startPrice: '',
+    buyNowPrice: '',
+    startDate: '2024 / 03 / 27',
+    startTime: '12 : 00 : 00',
+    endDate: '2024 / 03 / 27',
+    endTime: '12 : 00 : 00',
+  })
+
+  const headerTitle = computed(() => {
+    if (currentMode.value === 'inspection') return '검수 상품 신청'
+    if (currentMode.value === 'inspection-pick') return '사전 검수 상품 등록'
+    if (currentMode.value === 'direct') return '직접 상품 등록'
+    if (currentMode.value === 'direct-auction') return '경매 등록'
+    return '경매 등록 방법 선택'
+  })
+
+  const headerDescription = computed(() => {
+    if (currentMode.value === 'inspection') return '검수 상품 정보를 입력해주세요.'
+    if (currentMode.value === 'inspection-pick') return '검수가 완료된 상품을 선택해 경매에 등록해주세요.'
+    if (currentMode.value === 'direct') return '경매에 등록할 상품 정보를 입력해주세요.'
+    if (currentMode.value === 'direct-auction') return '경매 정보를 입력해주세요.'
+    return '경매 등록하실 방법을 선택해주세요.'
+  })
+
+  const thumbnailPlaceholders = computed(() =>
+    Math.max(0, 3 - Math.max(0, uploadedImages.value.length - 1)),
+  )
+
+  const successMessage = computed(() =>
+    currentMode.value === 'inspection'
+      ? '더미 데이터 기준으로 검수 상품 신청이 완료되었습니다.'
+      : currentMode.value === 'direct-auction'
+        ? registrationType.value === 'inspection'
+          ? '더미 데이터 기준으로 사전 검수 상품 경매 등록이 완료되었습니다.'
+          : '더미 데이터 기준으로 경매 등록이 완료되었습니다.'
+        : '더미 데이터 기준으로 직접 상품 등록이 완료되었습니다.',
+  )
+
+  const showStepper = computed(() =>
+    currentMode.value === 'inspection-pick' || currentMode.value === 'direct' || currentMode.value === 'direct-auction',
+  )
+  const isAuctionStep = computed(() => currentMode.value === 'direct-auction')
+  const firstStepLabel = computed(() =>
+    registrationType.value === 'inspection' ? '사전 검수 상품 등록' : '직접 상품 등록',
+  )
+  const bidUnitOptions = ['1,000', '5,000', '10,000', '50,000', '100,000', '직접입력']
+  const durationOptions = computed(() =>
+    auctionForm.value.timeDeal
+      ? ['4시간', '8시간', '12시간', '16시간', '20시간', '24시간', '28시간', '32시간', '36시간', '40시간', '44시간', '48시간']
+      : ['3일', '4일', '5일', '6일', '7일', '8일', '9일', '10일'],
+  )
+  const inspectionReadyItems = computed(() => inspectionItems.filter((item) => item.status === '검수 통과'))
+  const selectedInspectionItem = computed(() =>
+    inspectionReadyItems.value.length
+      ? inspectionReadyItems.value[selectedInspectionId.value % inspectionReadyItems.value.length]
+      : null,
+  )
+  const inspectionPickItems = computed(() => {
+    if (!inspectionReadyItems.value.length) return []
+
+    return Array.from({ length: 7 }, (_, index) => ({
+      ...inspectionReadyItems.value[index % inspectionReadyItems.value.length],
+      displayId: index,
+    }))
+  })
+
+  function openMode(mode) {
+    registrationType.value = mode === 'inspection' || mode === 'inspection-pick' ? 'inspection' : 'direct'
+    currentMode.value = mode
+    submitted.value = false
+  }
+
+  function handleFiles(event) {
+    const files = Array.from(event.target.files || [])
+    const remain = Math.max(0, 4 - uploadedImages.value.length)
+    const selected = files.slice(0, remain)
+
+    selected.forEach((file) => {
+      uploadedImages.value.push({
+        name: file.name,
+        previewUrl: URL.createObjectURL(file),
+      })
+    })
+
+    event.target.value = ''
+  }
+
+  function removeImage(index) {
+    const [image] = uploadedImages.value.splice(index, 1)
+
+    if (image?.previewUrl) {
+      URL.revokeObjectURL(image.previewUrl)
+    }
+  }
+
+  function resetForm() {
+    uploadedImages.value.forEach((image) => {
+      if (image.previewUrl) {
+        URL.revokeObjectURL(image.previewUrl)
+      }
+    })
+
+    uploadedImages.value = []
+    form.value = {
+      name: '',
+      category: '',
+      brand: '',
+      condition: '',
+      description: '',
+    }
+    submitted.value = false
+  }
+
+  function goBackToSelect() {
+    resetForm()
+    currentMode.value = 'select'
+  }
+
+  function submitForm() {
+    if (currentMode.value === 'direct' || currentMode.value === 'inspection-pick') {
+      currentMode.value = 'direct-auction'
+      submitted.value = false
+      return
+    }
+
+    submitted.value = true
+  }
+
+  function returnFromAuctionStep() {
+    currentMode.value = registrationType.value === 'inspection' ? 'inspection-pick' : 'direct'
+    submitted.value = false
+  }
+
+  function toggleAuctionField(field) {
+    auctionForm.value[field] = !auctionForm.value[field]
+
+    if (field === 'timeDeal') {
+      selectedDuration.value = auctionForm.value.timeDeal ? '12시간' : '5일'
+    }
+  }
+
+  function selectInspectionItem(index) {
+    selectedInspectionId.value = index
+    isInspectionDetailOpen.value = true
+  }
+
+  function closeInspectionDetail() {
+    isInspectionDetailOpen.value = false
+  }
+
+  function startAuctionFromInspection() {
+    isInspectionDetailOpen.value = false
+    currentMode.value = 'direct-auction'
+    submitted.value = false
+  }
+
+  watch(
+    initialMode,
+    (mode) => {
+      currentMode.value = allowedModes.includes(mode) ? mode : 'select'
+      registrationType.value = mode === 'inspection' || mode === 'inspection-pick' ? 'inspection' : 'direct'
+      submitted.value = false
+    },
+  )
+
+  onBeforeUnmount(() => {
+    uploadedImages.value.forEach((image) => {
+      if (image.previewUrl) {
+        URL.revokeObjectURL(image.previewUrl)
+      }
+    })
+  })
+
+  return {
+    auctionForm,
+    bidUnitOptions,
+    closeInspectionDetail,
+    currentMode,
+    durationOptions,
+    firstStepLabel,
+    form,
+    goBackToSelect,
+    handleFiles,
+    headerDescription,
+    headerTitle,
+    inspectionPickItems,
+    isAuctionStep,
+    isInspectionDetailOpen,
+    openMode,
+    removeImage,
+    returnFromAuctionStep,
+    selectedBidUnit,
+    selectedDuration,
+    selectedInspectionId,
+    selectedInspectionItem,
+    selectInspectionItem,
+    showStepper,
+    startAuctionFromInspection,
+    submitted,
+    submitForm,
+    successMessage,
+    thumbnailPlaceholders,
+    toggleAuctionField,
+    uploadedImages,
+  }
+}

--- a/src/data/marketplaceData.js
+++ b/src/data/marketplaceData.js
@@ -1,0 +1,126 @@
+export const assets = {
+  heroBackground: 'https://www.figma.com/api/mcp/asset/2c032067-2d24-4567-b3e8-93b8314cf536',
+  watchImage: 'https://www.figma.com/api/mcp/asset/efb38393-6d05-42e3-bdbd-49d9c50c580f',
+  homeIcon: 'https://www.figma.com/api/mcp/asset/cd652fb8-c0c4-4340-b0fd-ab57c46cacc2',
+  categoryIcon: 'https://www.figma.com/api/mcp/asset/74cf0ac8-a459-4052-b743-87dee931bff0',
+  registerIcon: 'https://www.figma.com/api/mcp/asset/cfd6b14c-3cb6-4eb7-99a8-5f03989fc719',
+  inspectionIcon: 'https://www.figma.com/api/mcp/asset/d48c2f9f-af52-43c5-a115-5c3eb00869bf',
+  searchIcon: 'https://www.figma.com/api/mcp/asset/9b2d42cb-846e-4175-8b6d-91f2732cca50',
+  clockIcon: 'https://www.figma.com/api/mcp/asset/83902904-0c6b-4584-94b0-e308a090e676',
+  heartIcon: 'https://www.figma.com/api/mcp/asset/4df025dc-4a10-4be3-aabb-72d7cd09fbbc',
+  listSearchIcon: 'https://www.figma.com/api/mcp/asset/b4053bac-f43a-41c8-9cec-70b678bc5248',
+  sortChevronIcon: 'https://www.figma.com/api/mcp/asset/4df20e91-7e32-47a7-8ea9-3c8deaf9a724',
+  listWatchImage: 'https://www.figma.com/api/mcp/asset/e8c9af76-2653-419a-8da5-b7a65a36822d',
+}
+
+export const navigationItems = [
+  { label: '홈', icon: assets.homeIcon, key: 'home' },
+  { label: '카테고리', icon: assets.categoryIcon, key: 'list' },
+  { label: '경매 등록', icon: assets.registerIcon, key: 'register' },
+  { label: '검수', icon: assets.inspectionIcon, key: 'inspection' },
+]
+
+function buildItem(overrides = {}) {
+  return {
+    title: '롤렉스 시계',
+    brand: '브랜드',
+    price: '8,000,000',
+    bids: '입찰 0회',
+    time: '7분',
+    highlight: false,
+    seller: '셀러111',
+    sellerGrade: 'GOLD',
+    description:
+      '2020년식 롤렉스 서브마리너 116610LN 모델입니다. 정기 점검을 받았으며, 모든 부속품과 보증서가 함께 제공됩니다. 실사용 흔적이 적고 베젤과 브레이슬릿 컨디션이 안정적으로 유지된 상품입니다.',
+    inspectionLabel: '검수 완료 상품',
+    inspectionDescription: '전문가 검수를 통과한 상품입니다.',
+    buyNowPrice: '9,100,000',
+    bidUnit: '100,000',
+    startDate: '2026.04.01 09:00',
+    endDate: '2026.04.01 23:59',
+    inquiries: [
+      {
+        status: '답변 완료',
+        title: '옥션 등록 절차에 대해 문의드립니다.',
+        meta: '김구매 | 2023.10.24 14:30',
+        question:
+          '안녕하세요. 이번에 처음으로 옥션에 물품을 등록해보려고 합니다. 감정 절차가 얼마나 걸리는지, 그리고 등록비용이 따로 발생하는지 궁금합니다.',
+        answer:
+          '안녕하세요, 고객님. 문의주신 감정 절차는 영업일 기준 통상 3~5일 정도 소요됩니다. 현재 신규 회원을 대상으로 첫 등록 무료 프로모션을 진행하고 있어 별도의 등록비용은 발생하지 않습니다.',
+      },
+      {
+        status: '답변 대기',
+        title: '계정 관련 문의가 있습니다.',
+        meta: '박구매 | 2023.10.23 17:10',
+        question:
+          '입찰 참여 후 결제 수단 변경이 가능한지 궁금합니다. 낙찰 이후 절차도 함께 확인하고 싶습니다.',
+        answer: '',
+      },
+    ],
+    history: [
+      { bidder: 'bidder01', amount: '8,000,000', date: '2026.04.01 09:12' },
+      { bidder: 'bidder02', amount: '7,900,000', date: '2026.04.01 08:48' },
+      { bidder: 'bidder03', amount: '7,800,000', date: '2026.04.01 08:11' },
+    ],
+    ...overrides,
+  }
+}
+
+export const bestItems = [
+  buildItem({ highlight: true }),
+  buildItem({ highlight: true }),
+  buildItem(),
+  buildItem(),
+]
+
+export const categoryGroups = [
+  { label: '대분류', active: true, indent: 0 },
+  { label: '중분류', active: false, indent: 1 },
+  { label: '중분류', active: true, indent: 1 },
+  { label: '소분류', active: true, indent: 2 },
+  { label: '소분류', active: false, indent: 2 },
+  { label: '소분류', active: false, indent: 2 },
+  { label: '소분류', active: false, indent: 2 },
+  { label: '중분류', active: false, indent: 1 },
+  { label: '중분류', active: false, indent: 1 },
+  { label: '대분류', active: false, indent: 0 },
+  { label: '대분류', active: false, indent: 0 },
+]
+
+export const listItems = [
+  buildItem({ highlight: true }),
+  buildItem({ highlight: true }),
+  buildItem(),
+  buildItem(),
+  buildItem({ highlight: true }),
+  buildItem(),
+]
+
+export const registerOptions = [
+  {
+    title: '사전 검수 상품 등록',
+    description:
+      '검수센터로 상품을 발송해 진품 여부와 상태를 먼저 검수받은 뒤 경매에 올리는 방식입니다. 신뢰도 높은 상품에 적합합니다.',
+    button: '검수 상품 등록하기',
+    tone: 'inspection',
+  },
+  {
+    title: '직접 상품 등록',
+    description:
+      '판매자가 사진과 상품 정보를 직접 입력해 즉시 경매 등록을 진행합니다. 빠르게 등록해야 하는 일반 상품에 적합합니다.',
+    button: '직접 등록하기',
+    tone: 'direct',
+  },
+]
+
+export const inspectionSummary = [
+  { label: '검수 대기', value: '12', tone: 'review' },
+  { label: '검수 완료', value: '28', tone: 'complete' },
+  { label: '등록 가능', value: '7', tone: 'ready' },
+]
+
+export const inspectionItems = [
+  buildItem({ title: '검수 완료 시계', highlight: true, time: '등록 대기' }),
+  buildItem({ title: '검수 완료 가방', time: '검수 완료' }),
+  buildItem({ title: '검수 완료 스니커즈', time: '검수 완료' }),
+]

--- a/src/data/marketplaceData.js
+++ b/src/data/marketplaceData.js
@@ -27,28 +27,31 @@ export const assets = {
 }
 
 export const navigationItems = [
-  { label: '홈', icon: assets.homeIcon, key: 'home' },
-  { label: '카테고리', icon: assets.categoryIcon, key: 'list' },
-  { label: '경매 등록', icon: assets.registerIcon, key: 'register' },
-  { label: '검수', icon: assets.inspectionIcon, key: 'inspection' },
+  { label: '홈', icon: assets.homeIcon, key: 'home', route: '/' },
+  { label: '카테고리', icon: assets.categoryIcon, key: 'list', route: '/auctions' },
+  { label: '경매 등록', icon: assets.registerIcon, key: 'register', route: '/register' },
+  { label: '검수', icon: assets.inspectionIcon, key: 'inspection', route: '/inspection' },
 ]
 
 export const mypageNavigationItems = [
-  { label: '대시보드', icon: assets.mypageDashboardIcon, key: 'mypage-dashboard', route: 'mypage' },
-  { label: '입찰 내역', icon: assets.mypageBidIcon, key: 'mypage-bids', route: 'mypage' },
-  { label: '관심 경매', icon: assets.mypageHeartIcon, key: 'mypage-hearts', route: 'mypage' },
-  { label: '구매 내역', icon: assets.mypageBuyIcon, key: 'mypage-buys', route: 'mypage' },
-  { label: '판매 내역', icon: assets.mypageSellIcon, key: 'mypage-sells', route: 'mypage' },
-  { label: '경매 관리', icon: assets.mypageSellIcon, key: 'mypage-auctions', route: 'mypage' },
-  { label: '프로필 관리', icon: assets.mypageProfileIcon, key: 'mypage-profile', route: 'mypage' },
-  { label: '주소록 관리', icon: assets.mypageAddressIcon, key: 'mypage-address', route: 'mypage' },
-  { label: '포인트 관리', icon: assets.mypagePointIcon, key: 'mypage-points', route: 'mypage' },
-  { label: '구매/판매 문의 내역', icon: assets.mypageInquiryIcon, key: 'mypage-qa', route: 'mypage' },
-  { label: '1:1 문의 내역', icon: assets.mypageOneToOneIcon, key: 'mypage-support', route: 'mypage' },
+  { label: '대시보드', icon: assets.mypageDashboardIcon, key: 'mypage-dashboard', route: '/mypage' },
+  { label: '입찰 내역', icon: assets.mypageBidIcon, key: 'mypage-bids', route: '/mypage' },
+  { label: '관심 경매', icon: assets.mypageHeartIcon, key: 'mypage-hearts', route: '/mypage' },
+  { label: '구매 내역', icon: assets.mypageBuyIcon, key: 'mypage-buys', route: '/mypage' },
+  { label: '판매 내역', icon: assets.mypageSellIcon, key: 'mypage-sells', route: '/mypage' },
+  { label: '경매 관리', icon: assets.mypageSellIcon, key: 'mypage-auctions', route: '/mypage' },
+  { label: '프로필 관리', icon: assets.mypageProfileIcon, key: 'mypage-profile', route: '/mypage' },
+  { label: '주소록 관리', icon: assets.mypageAddressIcon, key: 'mypage-address', route: '/mypage' },
+  { label: '포인트 관리', icon: assets.mypagePointIcon, key: 'mypage-points', route: '/mypage' },
+  { label: '구매/판매 문의 내역', icon: assets.mypageInquiryIcon, key: 'mypage-qa', route: '/mypage' },
+  { label: '1:1 문의 내역', icon: assets.mypageOneToOneIcon, key: 'mypage-support', route: '/mypage' },
 ]
+
+let itemSequence = 1
 
 function buildItem(overrides = {}) {
   return {
+    id: overrides.id ?? `auction-${itemSequence++}`,
     title: '롤렉스 시계',
     brand: '브랜드',
     price: '8,000,000',
@@ -198,3 +201,9 @@ export const mypagePurchaseItems = [
     date: '2026.03.03',
   },
 ]
+
+export const allAuctionItems = [...bestItems, ...listItems, ...inspectionItems]
+
+export function findAuctionItemById(id) {
+  return allAuctionItems.find((item) => item.id === id) ?? null
+}

--- a/src/data/marketplaceData.js
+++ b/src/data/marketplaceData.js
@@ -11,6 +11,19 @@ export const assets = {
   listSearchIcon: 'https://www.figma.com/api/mcp/asset/b4053bac-f43a-41c8-9cec-70b678bc5248',
   sortChevronIcon: 'https://www.figma.com/api/mcp/asset/4df20e91-7e32-47a7-8ea9-3c8deaf9a724',
   listWatchImage: 'https://www.figma.com/api/mcp/asset/e8c9af76-2653-419a-8da5-b7a65a36822d',
+  mypageAvatar: 'https://www.figma.com/api/mcp/asset/21f4d4a4-0d13-4186-b9f8-40a9d874c50e',
+  mypageBadge: 'https://www.figma.com/api/mcp/asset/6f341c54-0e36-4d5a-a893-0a1f78729967',
+  mypageProductImage: 'https://www.figma.com/api/mcp/asset/44924696-d661-434c-8b1f-c248e5201a84',
+  mypageDashboardIcon: 'https://www.figma.com/api/mcp/asset/887eca34-d802-4708-99ec-92945a1ba784',
+  mypageBidIcon: 'https://www.figma.com/api/mcp/asset/f3201d74-9473-482c-a76f-fd0b9c2bd915',
+  mypageHeartIcon: 'https://www.figma.com/api/mcp/asset/fe553cbd-b56a-4797-897a-2ba1fed296ba',
+  mypageBuyIcon: 'https://www.figma.com/api/mcp/asset/2e8c075b-2dfd-4e70-8205-7daaf7fddfc4',
+  mypageSellIcon: 'https://www.figma.com/api/mcp/asset/849e3f38-d4ae-4cd6-a8ed-0e3b5f0dc3a6',
+  mypageProfileIcon: 'https://www.figma.com/api/mcp/asset/bb9a67de-0694-4cdc-bc74-4b08ff97335a',
+  mypageAddressIcon: 'https://www.figma.com/api/mcp/asset/290690e0-e933-452d-b9ce-042e6f313e7e',
+  mypagePointIcon: 'https://www.figma.com/api/mcp/asset/5baeb94b-90df-4325-9145-cbb201e1300c',
+  mypageInquiryIcon: 'https://www.figma.com/api/mcp/asset/b1dd571d-44b7-473b-b0e5-441778c65ba9',
+  mypageOneToOneIcon: 'https://www.figma.com/api/mcp/asset/a1d7ee56-d641-48f2-ac43-e94e3f9cd34c',
 }
 
 export const navigationItems = [
@@ -18,6 +31,20 @@ export const navigationItems = [
   { label: '카테고리', icon: assets.categoryIcon, key: 'list' },
   { label: '경매 등록', icon: assets.registerIcon, key: 'register' },
   { label: '검수', icon: assets.inspectionIcon, key: 'inspection' },
+]
+
+export const mypageNavigationItems = [
+  { label: '대시보드', icon: assets.mypageDashboardIcon, key: 'mypage-dashboard', route: 'mypage' },
+  { label: '입찰 내역', icon: assets.mypageBidIcon, key: 'mypage-bids', route: 'mypage' },
+  { label: '관심 경매', icon: assets.mypageHeartIcon, key: 'mypage-hearts', route: 'mypage' },
+  { label: '구매 내역', icon: assets.mypageBuyIcon, key: 'mypage-buys', route: 'mypage' },
+  { label: '판매 내역', icon: assets.mypageSellIcon, key: 'mypage-sells', route: 'mypage' },
+  { label: '경매 관리', icon: assets.mypageSellIcon, key: 'mypage-auctions', route: 'mypage' },
+  { label: '프로필 관리', icon: assets.mypageProfileIcon, key: 'mypage-profile', route: 'mypage' },
+  { label: '주소록 관리', icon: assets.mypageAddressIcon, key: 'mypage-address', route: 'mypage' },
+  { label: '포인트 관리', icon: assets.mypagePointIcon, key: 'mypage-points', route: 'mypage' },
+  { label: '구매/판매 문의 내역', icon: assets.mypageInquiryIcon, key: 'mypage-qa', route: 'mypage' },
+  { label: '1:1 문의 내역', icon: assets.mypageOneToOneIcon, key: 'mypage-support', route: 'mypage' },
 ]
 
 function buildItem(overrides = {}) {
@@ -129,4 +156,45 @@ export const inspectionItems = [
   buildItem({ title: '에르메스 켈리', brand: '에르메스', status: '경매 진행 중', inspectionGrade: 'A+', inspectionDate: '2024 / 03 / 11' }),
   buildItem({ title: '롤렉스 시계', brand: '롤렉스', status: '검수 대기', inspectionGrade: 'A+', inspectionDate: '2024 / 03 / 27' }),
   buildItem({ title: '루이비통 알마', brand: '루이비통', status: '검수 반려', inspectionGrade: 'B+', inspectionDate: '2024 / 03 / 12' }),
+]
+
+export const mypageProfile = {
+  seller: '셀러111',
+  points: '1,850,000 P',
+}
+
+export const mypageBidItems = [
+  {
+    title: '갤럭시 S23 Ultra',
+    status: '경매 진행 중',
+    time: '7분',
+    currentPrice: '₩950,000',
+    myBidPrice: '₩950,000',
+    date: '2026.03.03',
+  },
+  {
+    title: '갤럭시 S23 Ultra',
+    status: '경매 진행 중',
+    time: '7분',
+    currentPrice: '₩950,000',
+    myBidPrice: '₩950,000',
+    date: '2026.03.03',
+  },
+]
+
+export const mypagePurchaseItems = [
+  {
+    title: '갤럭시 S23 Ultra',
+    status: '거래완료',
+    buyer: '김철수',
+    price: '₩950,000',
+    date: '2026.03.03',
+  },
+  {
+    title: '갤럭시 S23 Ultra',
+    status: '발송 대기',
+    buyer: '김철수',
+    price: '₩950,000',
+    date: '2026.03.03',
+  },
 ]

--- a/src/data/marketplaceData.js
+++ b/src/data/marketplaceData.js
@@ -114,13 +114,19 @@ export const registerOptions = [
 ]
 
 export const inspectionSummary = [
-  { label: '검수 대기', value: '12', tone: 'review' },
-  { label: '검수 완료', value: '28', tone: 'complete' },
-  { label: '등록 가능', value: '7', tone: 'ready' },
+  { label: '총 검수 완료', value: '1,284', tone: 'total' },
+  { label: '검수 대기', value: '42', tone: 'review' },
+  { label: '검수 승인', value: '15', tone: 'approve' },
+  { label: '경매 진행 중', value: '1,227', tone: 'auction' },
 ]
 
 export const inspectionItems = [
-  buildItem({ title: '검수 완료 시계', highlight: true, time: '등록 대기' }),
-  buildItem({ title: '검수 완료 가방', time: '검수 완료' }),
-  buildItem({ title: '검수 완료 스니커즈', time: '검수 완료' }),
+  buildItem({ title: '롤렉스 시계', brand: '롤렉스', status: '검수 통과', inspectionGrade: 'A+', inspectionDate: '2024 / 03 / 15' }),
+  buildItem({ title: '롤렉스 데이토나', brand: '롤렉스', status: '검수 통과', inspectionGrade: 'A', inspectionDate: '2024 / 03 / 18' }),
+  buildItem({ title: '오메가 씨마스터', brand: '오메가', status: '검수 통과', inspectionGrade: 'A+', inspectionDate: '2024 / 03 / 20' }),
+  buildItem({ title: '까르띠에 탱크', brand: '까르띠에', status: '검수 통과', inspectionGrade: 'A', inspectionDate: '2024 / 03 / 22' }),
+  buildItem({ title: '롤렉스 시계', brand: '롤렉스', status: '검수 대기', inspectionGrade: 'A+', inspectionDate: '2024 / 03 / 25' }),
+  buildItem({ title: '에르메스 켈리', brand: '에르메스', status: '경매 진행 중', inspectionGrade: 'A+', inspectionDate: '2024 / 03 / 11' }),
+  buildItem({ title: '롤렉스 시계', brand: '롤렉스', status: '검수 대기', inspectionGrade: 'A+', inspectionDate: '2024 / 03 / 27' }),
+  buildItem({ title: '루이비통 알마', brand: '루이비통', status: '검수 반려', inspectionGrade: 'B+', inspectionDate: '2024 / 03 / 12' }),
 ]

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import './styles/app.css'
 
 createApp(App).mount('#app')

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import router from './router'
 import './styles/app.css'
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,75 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import AuctionDetailView from '../views/AuctionDetailView.vue'
+import AuctionListView from '../views/AuctionListView.vue'
+import HomeView from '../views/HomeView.vue'
+import InspectionView from '../views/InspectionView.vue'
+import MyPageView from '../views/MyPageView.vue'
+import RegisterView from '../views/RegisterView.vue'
+
+const routes = [
+  {
+    path: '/',
+    name: 'home',
+    component: HomeView,
+    meta: {
+      navSection: 'main',
+      navKey: 'home',
+    },
+  },
+  {
+    path: '/auctions',
+    name: 'auctions',
+    component: AuctionListView,
+    meta: {
+      navSection: 'main',
+      navKey: 'list',
+    },
+  },
+  {
+    path: '/auctions/:id',
+    name: 'auction-detail',
+    component: AuctionDetailView,
+    meta: {
+      navSection: 'main',
+      navKey: 'list',
+    },
+  },
+  {
+    path: '/register',
+    name: 'register',
+    component: RegisterView,
+    meta: {
+      navSection: 'main',
+      navKey: 'register',
+    },
+  },
+  {
+    path: '/inspection',
+    name: 'inspection',
+    component: InspectionView,
+    meta: {
+      navSection: 'main',
+      navKey: 'inspection',
+    },
+  },
+  {
+    path: '/mypage',
+    name: 'mypage',
+    component: MyPageView,
+    meta: {
+      navSection: 'mypage',
+      navKey: 'mypage-dashboard',
+    },
+  },
+  {
+    path: '/:pathMatch(.*)*',
+    redirect: '/',
+  },
+]
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes,
+})
+
+export default router

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -167,6 +167,256 @@ img {
   padding: 30px 110px;
 }
 
+.mypage-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.mypage-header h2 {
+  margin: 0;
+  color: #000;
+  font-size: 30px;
+  font-weight: 500;
+  line-height: 36px;
+  letter-spacing: -0.75px;
+}
+
+.mypage-profile-card,
+.mypage-bid-card,
+.mypage-purchase-card {
+  border-radius: 32px;
+  background: #fff;
+  box-shadow: 5px 10px 30px 0 rgba(0, 0, 0, 0.08);
+}
+
+.mypage-profile-card {
+  padding: 30px 60px;
+}
+
+.mypage-profile-row {
+  display: flex;
+  align-items: center;
+}
+
+.mypage-profile-user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mypage-avatar {
+  width: 50px;
+  height: 50px;
+  border-radius: 999px;
+  box-shadow: 0 0 0 4px #e3dfff;
+}
+
+.mypage-user-copy {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mypage-badge {
+  width: 25px;
+  height: 28px;
+  object-fit: contain;
+}
+
+.mypage-user-copy strong {
+  color: #000;
+  font-size: 20px;
+  font-weight: 800;
+  line-height: 32px;
+}
+
+.mypage-points-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.mypage-points-block span {
+  color: #94a3b8;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+}
+
+.mypage-points-block strong {
+  color: #23008d;
+  font-size: 32px;
+  font-weight: 800;
+  line-height: 48px;
+}
+
+.mypage-section {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.mypage-section-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 0 8px;
+}
+
+.mypage-section-header h3 {
+  margin: 0;
+  color: #000;
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 32px;
+}
+
+.mypage-section-header button {
+  border: 0;
+  background: transparent;
+  color: #23008d;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+  cursor: pointer;
+}
+
+.mypage-bid-list,
+.mypage-purchase-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mypage-bid-card {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  padding: 30px;
+}
+
+.mypage-bid-image {
+  width: 128px;
+  height: 128px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.mypage-bid-content {
+  display: flex;
+  flex: 1;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.mypage-bid-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mypage-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-height: 23px;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 1px;
+}
+
+.mypage-chip.is-auction,
+.mypage-chip.is-complete {
+  background: #d8e3fb;
+  color: #23008d;
+}
+
+.mypage-chip.is-waiting {
+  background: #f2f4f6;
+  color: #9ca3af;
+}
+
+.mypage-bid-copy h4,
+.mypage-purchase-copy h4 {
+  margin: 0;
+  color: #000;
+  font-family: 'Manrope', 'Noto Sans KR', sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 28px;
+}
+
+.mypage-time {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.mypage-time img {
+  width: 16px;
+  height: 16px;
+}
+
+.mypage-time span,
+.mypage-purchase-copy p,
+.mypage-bid-prices span,
+.mypage-purchase-price span {
+  color: #94a3b8;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.mypage-bid-prices {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.mypage-bid-prices strong,
+.mypage-purchase-price strong {
+  color: #23008d;
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 32px;
+  letter-spacing: -0.6px;
+}
+
+.mypage-purchase-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 24px 40px;
+}
+
+.mypage-purchase-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mypage-purchase-copy p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.mypage-purchase-price {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
 .hero-section {
   position: relative;
   min-height: 400px;
@@ -517,12 +767,19 @@ img {
 .detail-chip {
   display: inline-flex;
   align-items: center;
+  border: 0;
   border-radius: 999px;
   background: #eef2ff;
   padding: 6px 16px;
   color: #23008d;
   font-size: 12px;
   font-weight: 700;
+  cursor: pointer;
+}
+
+.detail-report-trigger {
+  justify-content: center;
+  min-width: 76px;
 }
 
 .detail-grid {
@@ -686,6 +943,271 @@ img {
   color: #475569;
   font-size: 15px;
   line-height: 1.75;
+}
+
+.detail-inquiry-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.46);
+  padding: 24px;
+}
+
+.detail-inquiry-modal {
+  width: min(520px, 100%);
+  border-radius: 20px;
+  background: #fff;
+  padding: 30px;
+  box-shadow: 0 14px 34px -14px rgba(0, 0, 0, 0.25);
+}
+
+.detail-report-modal {
+  width: min(550px, 100%);
+  border-radius: 20px;
+  background: #fff;
+  padding: 30px;
+  box-shadow: 0 14px 34px -14px rgba(0, 0, 0, 0.25);
+}
+
+.detail-inquiry-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.detail-inquiry-header h3 {
+  margin: 0;
+  color: #000;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.detail-inquiry-close {
+  border: 0;
+  background: transparent;
+  color: #000;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.detail-inquiry-summary {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 30px;
+}
+
+.detail-inquiry-thumb {
+  width: 100px;
+  height: 100px;
+  border: 1px solid #f2f4f6;
+  border-radius: 6px;
+  object-fit: cover;
+}
+
+.detail-inquiry-summary-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.detail-inquiry-summary-copy strong {
+  color: #000;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 22.5px;
+}
+
+.detail-inquiry-summary-copy span {
+  color: #94a3b8;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.detail-inquiry-summary-copy em {
+  color: #23008d;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 800;
+  line-height: 32px;
+}
+
+.detail-inquiry-secret {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 16px;
+  color: #94a3b8;
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.detail-inquiry-secret input {
+  width: 16px;
+  height: 16px;
+  accent-color: #23008d;
+}
+
+.detail-inquiry-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.detail-inquiry-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.detail-inquiry-field span {
+  color: #000;
+  font-size: 14px;
+  line-height: 22.5px;
+}
+
+.detail-inquiry-field em {
+  color: #bc1d25;
+  font-style: normal;
+}
+
+.detail-inquiry-field input,
+.detail-inquiry-field textarea {
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: #f2f4f6;
+  padding: 15px;
+  color: #191c1e;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.detail-inquiry-field input {
+  height: 44px;
+}
+
+.detail-inquiry-field textarea {
+  min-height: 100px;
+  resize: none;
+}
+
+.detail-inquiry-field input::placeholder,
+.detail-inquiry-field textarea::placeholder {
+  color: #94a3b8;
+}
+
+.detail-inquiry-submit {
+  width: 100%;
+  height: 48px;
+  margin-top: 30px;
+  border: 0;
+  border-radius: 10px;
+  background: #23008d;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.detail-report-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.detail-report-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.detail-report-field > span {
+  color: #000;
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.detail-report-field em {
+  color: #bc1d25;
+  font-style: normal;
+}
+
+.detail-report-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.detail-report-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  height: 44px;
+  border: 0;
+  border-radius: 8px;
+  background: #f2f4f6;
+  padding: 0 14px;
+  color: #000;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.detail-report-radio {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  border: 1px solid #94a3b8;
+  border-radius: 999px;
+  background: #fff;
+  flex: 0 0 auto;
+}
+
+.detail-report-option.is-selected .detail-report-radio {
+  border-color: #bc1d25;
+  box-shadow: inset 0 0 0 4px #fff;
+  background: #bc1d25;
+}
+
+.detail-report-textarea {
+  width: 100%;
+  min-height: 100px;
+  border: 0;
+  border-radius: 8px;
+  background: #f2f4f6;
+  padding: 15px;
+  color: #191c1e;
+  font-size: 14px;
+  font-weight: 500;
+  resize: none;
+}
+
+.detail-report-textarea::placeholder {
+  color: #94a3b8;
+}
+
+.detail-report-submit {
+  width: 100%;
+  height: 44px;
+  margin-top: 30px;
+  border: 0;
+  border-radius: 10px;
+  background: #bc1d25;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.3);
+  cursor: pointer;
 }
 
 .inquiry-section {
@@ -2478,6 +3000,24 @@ img {
     width: 100%;
   }
 
+  .mypage-bid-card,
+  .mypage-purchase-card,
+  .mypage-bid-content,
+  .mypage-section-header,
+  .mypage-profile-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .mypage-profile-card {
+    padding: 30px;
+  }
+
+  .mypage-purchase-price,
+  .mypage-bid-prices {
+    align-items: flex-start;
+  }
+
   .list-toolbar {
     flex-direction: column;
     align-items: stretch;
@@ -2571,6 +3111,16 @@ img {
   .register-method-button,
   .inspection-action {
     width: 100%;
+  }
+
+  .mypage-bid-card,
+  .mypage-purchase-card {
+    padding: 24px;
+  }
+
+  .mypage-bid-image {
+    width: 100%;
+    height: 220px;
   }
 
   .detail-product-title {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -988,14 +988,11 @@ img {
   color: #23008d;
 }
 
-.register-header h2,
-.register-header p,
 .inspection-header h2,
 .inspection-header p {
   margin: 0;
 }
 
-.register-header h2,
 .inspection-header h2 {
   color: #191c1e;
   font-size: 32px;
@@ -1003,7 +1000,6 @@ img {
   line-height: 1.2;
 }
 
-.register-header p,
 .inspection-header p {
   margin-top: 8px;
   color: #64748b;
@@ -1011,68 +1007,574 @@ img {
   line-height: 1.6;
 }
 
-.register-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 24px;
+.register-method-header h2 {
+  margin: 0;
+  color: #191c1e;
+  font-size: 30px;
+  font-weight: 500;
+  line-height: 36px;
+  letter-spacing: -0.75px;
 }
 
-.register-card {
+.register-method-header p {
+  margin: 8px 0 0;
+  color: #94a3b8;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.register-stepper,
+.register-step,
+.register-form-grid,
+.register-actions,
+.register-thumb-row {
+  display: flex;
+}
+
+.register-stepper {
+  align-items: center;
+  gap: 16px;
+}
+
+.register-step {
+  align-items: center;
+  gap: 12px;
+  color: #94a3b8;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.register-step.is-active {
+  color: #191c1e;
+}
+
+.register-step-index {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: #23008d;
+  color: #fff;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.register-step-index.is-muted {
+  background: #9ca3af;
+  color: #f2f4f6;
+}
+
+.register-step-line {
+  width: 48px;
+  height: 1px;
+  background: #94a3b8;
+}
+
+.register-method-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 450px);
+  gap: 74px;
+  width: 100%;
+  max-width: 974px;
+}
+
+.register-method-card {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  min-height: 300px;
-  border-radius: 20px;
+  height: 420px;
+  border-radius: 16px;
   background: #fff;
-  padding: 28px;
-  box-shadow: 0 12px 32px -4px rgba(25, 28, 30, 0.06);
+  padding: 24px;
+  box-shadow:
+    5px 10px 30px 0 rgba(25, 28, 30, 0.08);
 }
 
-.register-card.is-inspection {
-  background: linear-gradient(180deg, #ffffff 0%, #f7fff9 100%);
-}
-
-.register-card.is-direct {
-  background: linear-gradient(180deg, #ffffff 0%, #f7f8ff 100%);
-}
-
-.register-icon {
+.register-method-icon-wrap {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
-  border-radius: 14px;
-  background: #23008d;
-  color: #fff;
-  font-size: 22px;
-  font-weight: 700;
+  width: 64px;
+  height: 64px;
+  border-radius: 12px;
+  background: #d8e3fb;
 }
 
-.register-card strong {
-  color: #191c1e;
+.register-method-icon {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+}
+
+.register-method-card.is-direct .register-method-icon-wrap {
+  background: #f2f4f6;
+}
+
+.register-method-card h3 {
+  margin: 32px 0 0;
+  color: #000;
   font-size: 24px;
-  line-height: 1.4;
+  font-weight: 500;
+  line-height: 32px;
 }
 
-.register-card p {
-  margin: 0;
-  color: #64748b;
-  font-size: 15px;
-  line-height: 1.8;
+.register-method-points {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 16px;
+  margin: 24px 0 0;
+  padding: 0 0 56px;
+  list-style: none;
 }
 
-.register-button,
+.register-method-point {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  color: #94a3b8;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 24px;
+}
+
+.register-method-bullet {
+  width: 16.667px;
+  height: 18.667px;
+  margin-top: 2px;
+  object-fit: contain;
+}
+
+.register-method-button,
 .inspection-action {
-  align-self: flex-start;
+  width: 100%;
+  height: 44px;
   border: 0;
-  border-radius: 14px;
-  background: #23008d;
-  padding: 14px 18px;
-  color: #fff;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.1);
+}
+
+.register-method-button.is-inspection {
+  background: #d8e3fb;
+  color: #23008d;
+}
+
+.register-method-button.is-direct {
+  background: #f2f4f6;
+  color: #23008d;
+}
+
+.register-form-card {
+  width: 100%;
+  max-width: 957px;
+  border-radius: 16px;
+  background: #fff;
+  padding: 32px;
+  box-shadow:
+    0 18px 40px -12px rgba(25, 28, 30, 0.08),
+    0 12px 32px -4px rgba(25, 28, 30, 0.06);
+}
+
+.register-inspection-pick-card {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  max-width: 957px;
+}
+
+.register-form-grid {
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 53px;
+}
+
+.register-upload-column {
+  width: 400px;
+}
+
+.register-hidden-input {
+  display: none;
+}
+
+.register-label {
+  display: block;
+  color: #191c1e;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.register-label span {
+  color: #bc1d25;
+}
+
+.register-upload-box {
+  width: 100%;
+  height: 400px;
+  margin-top: 15px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 0;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.register-upload-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  height: 100%;
+  color: #94a3b8;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.register-upload-icon {
+  display: grid;
+  place-items: center;
+  width: 27px;
+  height: 27px;
+  border-radius: 999px;
+  border: 2px solid #cbd5e1;
+  color: #94a3b8;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.register-main-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.register-thumb-row {
+  justify-content: space-between;
+  gap: 12.5px;
+  margin-top: 15px;
+}
+
+.register-thumb {
+  width: 125px;
+  height: 125px;
+  border-radius: 8px;
+  background: #f1f5f9;
+  border: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.register-thumb-image {
+  cursor: pointer;
+}
+
+.register-thumb-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.register-helper-text {
+  margin: 15px 0 0;
+  color: #94a3b8;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 24px;
+}
+
+.register-fields-column {
+  width: 440px;
+}
+
+.register-field {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.register-field + .register-field {
+  margin-top: 20px;
+}
+
+.register-field input,
+.register-field select,
+.register-field textarea {
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: #f2f4f6;
+  color: #191c1e;
+  padding: 15px;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.register-field input,
+.register-field select {
+  height: 44px;
+}
+
+.register-field textarea {
+  min-height: 100px;
+  resize: none;
+}
+
+.register-select-wrap {
+  position: relative;
+}
+
+.register-select-wrap::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid #94a3b8;
+  border-bottom: 1.5px solid #94a3b8;
+  transform: translateY(-70%) rotate(45deg);
+  pointer-events: none;
+}
+
+.register-select-wrap select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 36px;
+}
+
+.register-auction-card {
+  padding: 32px 32px 24px;
+}
+
+.auction-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.auction-toggle-grid,
+.auction-field-grid,
+.auction-date-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.auction-toggle-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 14px 16px;
+}
+
+.auction-toggle-copy {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.auction-toggle-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
   font-size: 15px;
   font-weight: 700;
+}
+
+.auction-toggle-icon.is-extend {
+  color: #23008d;
+  background: #ede9fe;
+}
+
+.auction-toggle-icon.is-timedeal {
+  color: #dc2626;
+  background: #fee2e2;
+}
+
+.auction-toggle-copy strong {
+  display: block;
+  color: #191c1e;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.auction-toggle-copy p {
+  margin: 2px 0 0;
+  color: #94a3b8;
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.auction-switch {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  border: 0;
+  border-radius: 999px;
+  background: #cbd5e1;
+  padding: 2px;
   cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.auction-switch span {
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: #fff;
+  transition: transform 0.2s ease;
+}
+
+.auction-switch.is-on {
+  background: #23008d;
+}
+
+.auction-switch.is-on.is-danger {
+  background: #d92d20;
+}
+
+.auction-switch.is-on span {
+  transform: translateX(20px);
+}
+
+.auction-money-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  border-radius: 8px;
+  background: #f2f4f6;
+  padding: 0 14px;
+}
+
+.auction-money-field input {
+  border: 0;
+  background: transparent;
+  padding: 14px 0;
+}
+
+.auction-money-field span {
+  color: #94a3b8;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.auction-option-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.auction-chip-row {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.auction-chip-row.is-duration {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.auction-chip {
+  min-height: 40px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.auction-chip.is-selected {
+  background: #f3f0ff;
+  color: #23008d;
+}
+
+.auction-date-card {
+  border-radius: 12px;
+  background: #f2f4f6;
+  padding: 14px 16px;
+}
+
+.auction-date-label {
+  display: block;
+  color: #94a3b8;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.auction-date-value-row {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-top: 10px;
+}
+
+.auction-date-value {
+  color: #64748b;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.register-field input::placeholder,
+.register-field textarea::placeholder,
+.register-field select {
+  color: #94a3b8;
+}
+
+.register-success-banner {
+  margin-top: 20px;
+  border-radius: 12px;
+  background: #ecfdf5;
+  padding: 14px 16px;
+  color: #15803d;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.register-actions {
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 40px;
+}
+
+.register-secondary-button,
+.register-primary-button {
+  width: 215px;
+  height: 44px;
+  border: 0;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.1);
+}
+
+.register-secondary-button {
+  background: #f2f4f6;
+  color: #94a3b8;
+}
+
+.register-primary-button {
+  background: #23008d;
+  color: #fff;
 }
 
 .inspection-header {
@@ -1084,46 +1586,746 @@ img {
 
 .inspection-summary-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 18px;
+  grid-template-columns: repeat(4, 216px);
+  gap: 24px;
 }
 
 .inspection-summary-card {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  border-radius: 18px;
+  align-items: center;
+  gap: 12px;
+  height: 86px;
+  border-radius: 10px;
   background: #fff;
-  padding: 20px;
-  box-shadow: 0 12px 32px -4px rgba(25, 28, 30, 0.06);
+  padding: 17px;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 }
 
-.inspection-summary-card span {
-  color: #64748b;
+.inspection-summary-icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  color: #94a3b8;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.inspection-summary-icon.is-total,
+.inspection-summary-icon.is-review,
+.inspection-summary-icon.is-auction {
+  background: #d8e3fb;
+  color: #23008d;
+}
+
+.inspection-summary-icon.is-approve {
+  background: #f2f4f6;
+  color: #94a3b8;
+}
+
+.inspection-summary-copy {
+  display: flex;
+  flex-direction: column;
+}
+
+.inspection-summary-copy span {
+  color: #94a3b8;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.inspection-summary-copy strong {
+  color: #000;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 32px;
+}
+
+.inspection-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 960px;
+  padding: 16px;
+}
+
+.register-inspection-toolbar {
+  width: 100%;
+  padding: 0;
+  justify-content: flex-end;
+}
+
+.inspection-filters {
+  display: flex;
+  gap: 10px;
+}
+
+.inspection-filter {
+  width: 100px;
+  height: 32px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.inspection-filter.is-active {
+  background: #f3f6fe;
+  color: #23008d;
+}
+
+.inspection-search {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 337px;
+  height: 38px;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0 16px;
+  color: #94a3b8;
   font-size: 14px;
 }
 
-.inspection-summary-card strong {
-  color: #191c1e;
-  font-size: 28px;
-}
-
-.inspection-summary-card.is-review {
-  border-left: 4px solid #f59e0b;
-}
-
-.inspection-summary-card.is-complete {
-  border-left: 4px solid #22c55e;
-}
-
-.inspection-summary-card.is-ready {
-  border-left: 4px solid #23008d;
+.inspection-search-icon {
+  width: 18px;
+  height: 24px;
 }
 
 .inspection-card-grid {
   display: grid;
-  grid-template-columns: repeat(3, 216px);
+  grid-template-columns: repeat(4, 216px);
   gap: 30px;
+}
+
+.register-inspection-grid {
+  width: 100%;
+  grid-template-columns: repeat(4, 216px);
+  gap: 22px 31px;
+}
+
+.inspection-product-card {
+  width: 216px;
+  overflow: hidden;
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 4px 4px 30px 0 rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+}
+
+.register-inspection-card {
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+  background: #fff;
+}
+
+.register-inspection-card.is-selected {
+  border-color: #23008d;
+  transform: translateY(-2px);
+  box-shadow: 0 16px 40px -18px rgba(35, 0, 141, 0.45);
+}
+
+.inspection-product-image-wrap {
+  position: relative;
+  width: 216px;
+  height: 213px;
+  background: #f2f4f6;
+}
+
+.inspection-product-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.inspection-badge {
+  position: absolute;
+  right: 8px;
+  bottom: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 68px;
+  height: 23px;
+  border-radius: 999px;
+  padding: 0 12px;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 1px;
+}
+
+.inspection-badge.is-pending {
+  background: #f3f6fe;
+  color: #23008d;
+}
+
+.inspection-badge.is-passed {
+  background: #e3f5ec;
+  color: #22c55e;
+}
+
+.inspection-badge.is-rejected {
+  background: #f9e9ea;
+  color: #bc1d25;
+}
+
+.inspection-badge.is-auction {
+  background: #d8e3fb;
+  color: #23008d;
+}
+
+.inspection-product-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 15px;
+}
+
+.inspection-product-body h3 {
+  margin: 0;
+  color: #000;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.inspection-product-meta {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.inspection-product-meta div {
+  display: flex;
+  flex-direction: column;
+}
+
+.inspection-product-meta span {
+  color: #94a3b8;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.inspection-product-meta div strong {
+  color: #23008d;
+  font-size: 20px;
+  font-weight: 800;
+  line-height: 28px;
+}
+
+.register-inspection-card .inspection-product-image-wrap {
+  width: 214px;
+  background: #000;
+}
+
+.register-inspection-card .inspection-product-body {
+  padding: 14px 14px 13px;
+}
+
+.register-inspection-card .inspection-product-body h3 {
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.register-inspection-card .inspection-product-meta span {
+  line-height: 20px;
+}
+
+.register-inspection-card .inspection-product-meta div strong {
+  font-size: 30px;
+}
+
+.register-empty-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 216px;
+  min-height: 328px;
+  border: 1px dashed #94a3b8;
+  border-radius: 16px;
+  background: transparent;
+}
+
+.register-empty-icon {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 10px;
+  border-radius: 999px;
+  background: #f2f4f6;
+  color: #94a3b8;
+  font-size: 28px;
+  line-height: 1;
+}
+
+.register-empty-card strong {
+  color: #191c1e;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.register-empty-card p {
+  width: 104px;
+  margin: 0;
+  color: #9ca3af;
+  font-size: 12px;
+  line-height: 19.5px;
+  text-align: center;
+}
+
+.inspection-detail-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.46);
+  padding: 24px;
+}
+
+.inspection-detail-modal {
+  position: relative;
+  width: min(720px, 100%);
+  border-radius: 20px;
+  background: #fff;
+  padding: 30px;
+}
+
+.inspection-detail-close {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  border: 0;
+  background: transparent;
+  color: #000;
+  font-size: 30px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.inspection-detail-grid {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 20px;
+}
+
+.inspection-detail-image-card {
+  overflow: hidden;
+  border-radius: 10px;
+  background: #000;
+}
+
+.inspection-detail-image {
+  display: block;
+  width: 100%;
+  height: 320px;
+  object-fit: cover;
+}
+
+.inspection-detail-summary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.inspection-detail-category {
+  margin: 0;
+  color: #000;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 28px;
+}
+
+.inspection-detail-summary h3 {
+  margin: 0;
+  color: #000;
+  font-size: 40px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.inspection-detail-meta {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.inspection-detail-meta div {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.inspection-detail-meta span {
+  color: #94a3b8;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.inspection-detail-meta strong {
+  color: #000;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 28px;
+}
+
+.inspection-detail-meta strong.is-grade {
+  color: #23008d;
+  font-size: 20px;
+  font-weight: 800;
+}
+
+.inspection-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.inspection-detail-section h4 {
+  margin: 0;
+  color: #000;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.inspection-detail-section p {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 14px;
+  line-height: 22.75px;
+}
+
+.inspection-detail-section:last-child p {
+  color: #000;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 24px;
+}
+
+.inspection-detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 20px;
+  margin-top: 30px;
+}
+
+.inspection-detail-actions .register-secondary-button,
+.inspection-detail-actions .register-primary-button {
+  width: 320px;
+}
+
+.inspection-status-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.46);
+  padding: 24px;
+}
+
+.inspection-status-modal {
+  position: relative;
+  width: min(720px, 100%);
+  border-radius: 20px;
+  background: #fff;
+  padding: 30px;
+}
+
+.inspection-status-close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  border: 0;
+  background: transparent;
+  color: #000;
+  font-size: 30px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.inspection-status-grid {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 20px;
+}
+
+.inspection-status-image-card {
+  overflow: hidden;
+  border-radius: 10px;
+  background: #000;
+}
+
+.inspection-status-image {
+  display: block;
+  width: 100%;
+  height: 320px;
+  object-fit: cover;
+}
+
+.inspection-status-summary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.inspection-status-category {
+  margin: 0;
+  color: #000;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 28px;
+}
+
+.inspection-status-summary h3 {
+  margin: 0;
+  color: #000;
+  font-size: 40px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.inspection-status-meta {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  gap: 12px;
+}
+
+.inspection-status-meta div {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.inspection-status-meta span {
+  color: #94a3b8;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.inspection-status-meta strong {
+  color: #000;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 28px;
+}
+
+.inspection-status-meta strong.is-grade {
+  color: #23008d;
+  font-size: 20px;
+  font-weight: 800;
+}
+
+.inspection-status-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.inspection-status-section h4 {
+  margin: 0;
+  color: #000;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.inspection-status-section p {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 14px;
+  line-height: 22.75px;
+}
+
+.inspection-status-section > p:last-child,
+.inspection-status-section > p:nth-last-child(2) {
+  color: #000;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 24px;
+}
+
+.inspection-status-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  width: 100%;
+  min-height: 100px;
+  border-radius: 10px;
+  background: #f9e9ea;
+  padding: 16px;
+}
+
+.inspection-status-alert-icon {
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  border: 1.5px solid #bc1d25;
+  border-radius: 999px;
+  color: #bc1d25;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.inspection-status-alert p {
+  color: #bc1d25;
+  line-height: 20px;
+}
+
+.inspection-status-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 20px;
+  margin-top: 30px;
+}
+
+.inspection-status-actions .register-secondary-button,
+.inspection-status-actions .register-primary-button {
+  width: 320px;
+}
+
+.inspection-shipping-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.46);
+  padding: 24px;
+}
+
+.inspection-shipping-modal {
+  width: min(496px, 100%);
+  border-radius: 20px;
+  background: #fff;
+  padding: 24px 22px 22px;
+  box-shadow: 0 14px 34px -14px rgba(0, 0, 0, 0.25);
+}
+
+.inspection-shipping-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.inspection-shipping-header h3 {
+  margin: 0;
+  color: #000;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.inspection-shipping-close {
+  border: 0;
+  background: transparent;
+  color: #000;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.inspection-shipping-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.inspection-shipping-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.inspection-shipping-field.is-small {
+  width: 150px;
+}
+
+.inspection-shipping-field span {
+  color: #000;
+  font-size: 14px;
+  line-height: 22.5px;
+}
+
+.inspection-shipping-field em {
+  color: #bc1d25;
+  font-style: normal;
+}
+
+.inspection-shipping-field input,
+.inspection-shipping-field select {
+  width: 100%;
+  height: 44px;
+  border: 0;
+  border-radius: 8px;
+  background: #f2f4f6;
+  padding: 15px;
+  color: #191c1e;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.inspection-shipping-field select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 36px;
+  color: #94a3b8;
+}
+
+.inspection-shipping-field input::placeholder {
+  color: #94a3b8;
+}
+
+.inspection-shipping-submit {
+  width: 100%;
+  height: 44px;
+  margin-top: 20px;
+  border: 0;
+  border-radius: 10px;
+  background: #23008d;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.inspection-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: auto;
+  padding: 12px 24px;
+  border-radius: 16px;
+  background: #23008d;
+  color: #fff;
+}
+
+.inspection-action-plus {
+  font-size: 20px;
+  line-height: 1;
 }
 
 @media (max-width: 1340px) {
@@ -1154,6 +2356,7 @@ img {
     grid-template-columns: 1fr;
   }
 
+  .inspection-summary-grid,
   .inspection-card-grid {
     grid-template-columns: repeat(2, 216px);
   }
@@ -1205,7 +2408,10 @@ img {
     grid-template-columns: 1fr;
   }
 
-  .register-grid,
+  .auction-toggle-grid,
+  .auction-field-grid,
+  .auction-date-grid,
+  .register-method-grid,
   .inspection-summary-grid {
     grid-template-columns: 1fr;
   }
@@ -1218,10 +2424,79 @@ img {
     align-items: flex-start;
   }
 
+  .inspection-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+    width: 100%;
+    padding: 0;
+  }
+
+  .inspection-filters {
+    flex-wrap: wrap;
+  }
+
+  .inspection-search {
+    width: 100%;
+  }
+
+  .inspection-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .inspection-detail-image {
+    height: 280px;
+  }
+
+  .inspection-detail-actions {
+    flex-direction: column;
+  }
+
+  .inspection-detail-actions .register-secondary-button,
+  .inspection-detail-actions .register-primary-button {
+    width: 100%;
+  }
+
+  .inspection-status-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .inspection-status-image {
+    height: 280px;
+  }
+
+  .inspection-status-actions {
+    flex-direction: column;
+  }
+
+  .inspection-status-actions .register-secondary-button,
+  .inspection-status-actions .register-primary-button {
+    width: 100%;
+  }
+
+  .inspection-shipping-field.is-small {
+    width: 100%;
+  }
+
   .list-toolbar {
     flex-direction: column;
     align-items: stretch;
     gap: 12px;
+  }
+
+  .register-form-grid {
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .register-upload-column,
+  .register-fields-column {
+    width: 100%;
+  }
+
+  .auction-chip-row,
+  .auction-chip-row.is-duration {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .list-search {
@@ -1259,6 +2534,43 @@ img {
   .list-grid,
   .inspection-card-grid {
     grid-template-columns: 1fr;
+  }
+
+  .register-inspection-card,
+  .inspection-product-image-wrap,
+  .register-empty-card {
+    width: 100%;
+  }
+
+  .register-method-grid {
+    max-width: 450px;
+    gap: 24px;
+  }
+
+  .register-stepper {
+    flex-wrap: wrap;
+  }
+
+  .auction-chip-row,
+  .auction-chip-row.is-duration {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .auction-date-value-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .register-actions {
+    flex-direction: column;
+  }
+
+  .register-secondary-button,
+  .register-primary-button,
+  .register-method-button,
+  .inspection-action {
+    width: 100%;
   }
 
   .detail-product-title {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -903,10 +903,14 @@ img {
   gap: 10px;
 }
 
-.seller-name {
+.seller-name-button {
+  border: 0;
+  background: transparent;
+  padding: 0;
   color: #191c1e;
   font-size: 24px;
   font-weight: 600;
+  cursor: pointer;
 }
 
 .seller-grade {
@@ -977,6 +981,191 @@ img {
   background: #fff;
   padding: 30px;
   box-shadow: 0 14px 34px -14px rgba(0, 0, 0, 0.25);
+}
+
+.detail-seller-modal {
+  width: min(672px, 100%);
+  max-height: min(86vh, 760px);
+  overflow: auto;
+  border-radius: 12px;
+  background: #fff;
+  padding: 24px 30px 30px;
+  box-shadow: 0 12px 32px -4px rgba(25, 28, 30, 0.12);
+}
+
+.detail-seller-modal-header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.detail-seller-profile {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 0 32px;
+}
+
+.detail-seller-avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 999px;
+  box-shadow: 0 0 0 4px #e3dfff;
+  object-fit: cover;
+}
+
+.detail-seller-copy {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.detail-seller-name-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.detail-seller-badge {
+  width: 50px;
+  height: 57px;
+  object-fit: contain;
+}
+
+.detail-seller-name-row strong {
+  color: #000;
+  font-size: 32px;
+  font-weight: 800;
+  line-height: 32px;
+}
+
+.detail-seller-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.detail-seller-rating,
+.detail-seller-review-stars {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.detail-seller-star {
+  color: #23008d;
+  font-size: 15px;
+  line-height: 1;
+}
+
+.detail-seller-rating-value {
+  margin-left: 6px;
+  color: #000;
+  font-family: 'Inter', 'Noto Sans KR', sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 24px;
+}
+
+.detail-seller-review-count,
+.detail-seller-joined {
+  color: #000;
+  font-family: 'Inter', 'Noto Sans KR', sans-serif;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.detail-seller-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.detail-seller-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 90px;
+  border-radius: 12px;
+  background: #f2f4f6;
+  padding: 16px;
+}
+
+.detail-seller-stat-card span {
+  color: #94a3b8;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.detail-seller-stat-card strong {
+  color: #000;
+  font-size: 24px;
+  font-weight: 800;
+  line-height: 32px;
+}
+
+.detail-seller-reviews {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-top: 18px;
+}
+
+.detail-seller-reviews h3 {
+  margin: 0;
+  color: #000;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 28px;
+}
+
+.detail-seller-review {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.detail-seller-review-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.detail-seller-review-top strong {
+  display: block;
+  color: #000;
+  font-family: 'Inter', 'Noto Sans KR', sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 20px;
+}
+
+.detail-seller-review-top span {
+  display: block;
+  color: #000;
+  font-family: 'Inter', 'Noto Sans KR', sans-serif;
+  font-size: 10px;
+  line-height: 15px;
+}
+
+.detail-seller-review-image {
+  width: 72px;
+  height: 72px;
+  margin-left: 16px;
+  border-radius: 15px;
+  object-fit: cover;
+}
+
+.detail-seller-review p {
+  margin: 0;
+  padding-left: 16px;
+  color: #000;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 22.75px;
 }
 
 .detail-history-drawer-overlay {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,1275 @@
+@import url('https://cdn.jsdelivr.net/npm/pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@700&family=Manrope:wght@400&family=Roboto:wght@400;700&display=swap');
+
+:root {
+  font-family: 'Pretendard Variable', Pretendard, 'Noto Sans KR', sans-serif;
+  color: #000;
+  background: #f8fafc;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  --brand-color: #23008d;
+  --muted-text: #94a3b8;
+  --search-bg: #f2f4f6;
+  --page-bg: #f8fafc;
+  --hover-bg: #f3f6fe;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--page-bg);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+.page-shell {
+  display: grid;
+  grid-template-columns: 263px minmax(0, 1fr);
+  min-height: 100vh;
+  background: var(--page-bg);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  min-height: 100vh;
+}
+
+.brand-block {
+  padding: 24px;
+}
+
+.brand-title {
+  margin: 0;
+  color: var(--brand-color);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 32px;
+  letter-spacing: -0.6px;
+}
+
+.brand-subtitle {
+  margin: 4px 0 0;
+  color: var(--muted-text);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  letter-spacing: 1.2px;
+}
+
+.navigation {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  padding: 12px 16px;
+  color: var(--muted-text);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 20px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.nav-item.is-active {
+  border-right: 4px solid var(--brand-color);
+  border-radius: 0;
+  background: var(--hover-bg);
+  color: var(--brand-color);
+}
+
+.nav-icon {
+  width: 32px;
+  height: 20px;
+  object-fit: contain;
+}
+
+.main-area {
+  min-width: 0;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 110px;
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 660px;
+  max-width: 100%;
+  height: 39px;
+  border-radius: 19.5px;
+  background: var(--search-bg);
+  padding: 0 20px;
+  color: var(--muted-text);
+  font-family: 'Manrope', 'Noto Sans KR', sans-serif;
+  font-size: 14px;
+}
+
+.search-icon {
+  width: 18px;
+  height: 24px;
+  object-fit: contain;
+}
+
+.top-links {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.top-links button {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #000;
+  font-size: 14px;
+  line-height: normal;
+  cursor: pointer;
+}
+
+.content {
+  padding: 30px 110px;
+}
+
+.hero-section {
+  position: relative;
+  min-height: 400px;
+  overflow: hidden;
+  border-radius: 25px;
+  background: #000;
+}
+
+.hero-background {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.6;
+}
+
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.45) 0%, rgba(0, 0, 0, 0.08) 70%);
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 672px;
+  height: 100%;
+  min-height: 400px;
+  padding: 50px;
+}
+
+.hero-copy h2 {
+  margin: 0;
+  color: #fff;
+  font-size: 50px;
+  font-weight: 500;
+  line-height: 52.8px;
+  letter-spacing: -1.2px;
+}
+
+.hero-copy p {
+  margin: 0;
+  color: #f2f4f6;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 29.25px;
+}
+
+.hero-button {
+  align-self: flex-start;
+  border: 0;
+  border-radius: 16px;
+  background: var(--brand-color);
+  padding: 17px 32px;
+  color: #fff;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+  cursor: pointer;
+}
+
+.best-section {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  margin-top: 45px;
+}
+
+.section-heading h3 {
+  margin: 0;
+  color: #000;
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 36px;
+  letter-spacing: -0.75px;
+}
+
+.section-heading p {
+  margin: 8px 0 0;
+  color: var(--muted-text);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 24px;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 216px);
+  gap: 31px;
+}
+
+.list-screen {
+  display: grid;
+  grid-template-columns: 239px 708px;
+  gap: 10px;
+}
+
+.category-column {
+  min-height: 568px;
+  border-right: 1px solid #f2f4f6;
+  padding-right: 1px;
+}
+
+.category-button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  padding: 12px 16px;
+  color: #94a3b8;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  cursor: pointer;
+}
+
+.category-button.is-active {
+  background: #f3f6fe;
+  color: #23008d;
+  font-weight: 600;
+}
+
+.category-button.is-indent-1 {
+  padding-left: 24px;
+}
+
+.category-button.is-indent-2 {
+  padding-left: 32px;
+}
+
+.list-column {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.list-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 266.89px;
+}
+
+.list-search {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 459px;
+  height: 38px;
+  border-radius: 16px;
+  background: #fff;
+  padding: 0 16px;
+  color: #94a3b8;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.list-search-icon {
+  width: 18px;
+  height: 24px;
+}
+
+.sort-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 0;
+  background: transparent;
+  color: #23008d;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 20px;
+  cursor: pointer;
+}
+
+.sort-button img {
+  width: 16px;
+  height: 16px;
+}
+
+.list-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 216px);
+  gap: 30px;
+}
+
+.item-card {
+  position: relative;
+  width: 216px;
+  height: 358px;
+  border-radius: 15px;
+  background: #fff;
+  box-shadow:
+    0 12px 32px -4px rgba(25, 28, 30, 0.06),
+    4px 4px 30px 0 rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+}
+
+.item-card.is-highlight {
+  border: 2px solid #f1ff88;
+}
+
+.item-image-wrap {
+  position: relative;
+  width: 214px;
+  height: 213px;
+  overflow: hidden;
+  border-radius: 14px 14px 0 0;
+}
+
+.item-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.live-tag {
+  position: absolute;
+  top: 13px;
+  left: 14px;
+  z-index: 1;
+  border-radius: 9999px;
+  background: #bc1d25;
+  padding: 4px 12px;
+  color: #fff;
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 15px;
+  letter-spacing: 1px;
+}
+
+.wish-button {
+  position: absolute;
+  top: 154px;
+  right: 11px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 0;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(6px);
+  cursor: pointer;
+}
+
+.wish-button img {
+  width: 20px;
+  height: 18.35px;
+}
+
+.item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 15px;
+}
+
+.item-title {
+  margin: 0;
+  color: #000;
+  font-family: 'Roboto', 'Noto Sans KR', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.4;
+}
+
+.price-block {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.4;
+  color: #000;
+}
+
+.price-block span {
+  font-family: 'Roboto', 'Noto Sans KR', sans-serif;
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.price-block strong {
+  font-family: 'Roboto', sans-serif;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.item-meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 20px;
+  color: #000;
+  font-family: 'Roboto', 'Noto Sans KR', sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.4;
+}
+
+.divider {
+  width: 1px;
+  height: 22px;
+  background: #9ca3af;
+}
+
+.time-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.time-meta img {
+  width: 16px;
+  height: 16px;
+}
+
+.detail-screen,
+.register-screen,
+.inspection-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.detail-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 957px;
+}
+
+.detail-breadcrumb {
+  color: #191c1e;
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 32px;
+}
+
+.detail-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: #eef2ff;
+  padding: 6px 16px;
+  color: #23008d;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: 480px 450px;
+  gap: 27px;
+  align-items: start;
+}
+
+.detail-left,
+.detail-right {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.detail-image-card,
+.seller-card,
+.detail-description-card,
+.price-panel,
+.history-panel,
+.inquiry-item {
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 12px 32px -4px rgba(25, 28, 30, 0.06);
+}
+
+.detail-image-card {
+  position: relative;
+  overflow: hidden;
+  height: 376px;
+  background: #000;
+}
+
+.detail-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.gallery-arrow {
+  position: absolute;
+  top: 168px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #475569;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.gallery-arrow-left {
+  left: 16px;
+}
+
+.gallery-arrow-right {
+  right: 16px;
+}
+
+.inspection-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-radius: 16px;
+  background: #dff7ec;
+  padding: 16px;
+}
+
+.inspection-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 2px solid #22c55e;
+  border-radius: 999px;
+  color: #22c55e;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.inspection-banner strong {
+  color: #22c55e;
+  font-size: 14px;
+}
+
+.inspection-banner p {
+  margin: 4px 0 0;
+  color: #7b96a6;
+  font-size: 14px;
+}
+
+.seller-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px;
+}
+
+.seller-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.seller-avatar {
+  width: 50px;
+  height: 50px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #dbe5ff, #cbd5e1);
+}
+
+.seller-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.seller-name {
+  color: #191c1e;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.seller-grade {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 30px;
+  height: 34px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #fbbf24, #f59e0b);
+  padding: 0 10px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.seller-button {
+  border: 0;
+  border-radius: 12px;
+  background: #23008d;
+  padding: 8px 16px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.detail-description-card {
+  padding: 25px 24px;
+}
+
+.detail-description-card p {
+  margin: 0;
+  color: #475569;
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+.inquiry-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.inquiry-heading,
+.history-heading {
+  color: #191c1e;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 24px;
+}
+
+.inquiry-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.inquiry-item {
+  overflow: hidden;
+}
+
+.inquiry-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px;
+}
+
+.inquiry-summary-left {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 65px;
+  height: 26px;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #16a34a;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.status-badge.is-pending {
+  background: #e5e7eb;
+  color: #64748b;
+}
+
+.inquiry-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.inquiry-text strong {
+  color: #191c1e;
+  font-size: 20px;
+  line-height: 24px;
+}
+
+.inquiry-text span {
+  color: #64748b;
+  font-size: 14px;
+  line-height: 16px;
+}
+
+.inquiry-toggle {
+  color: #94a3b8;
+  font-size: 24px;
+}
+
+.inquiry-detail {
+  border-top: 1px solid #e5e7eb;
+  padding: 18px 24px 24px;
+}
+
+.question-box,
+.answer-box {
+  border-radius: 16px;
+  background: #f8fafc;
+  padding: 18px 20px;
+  color: #475569;
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.answer-box {
+  margin-top: 16px;
+}
+
+.answer-label {
+  margin-bottom: 10px;
+  color: #23008d;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.answer-box p {
+  margin: 0;
+}
+
+.price-panel {
+  padding: 20px 20px 24px;
+}
+
+.price-top-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.price-tags {
+  display: flex;
+  gap: 10px;
+}
+
+.price-tag {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 7px 14px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.price-tag.is-danger {
+  background: #ef4444;
+  color: #fff;
+}
+
+.price-tag.is-light {
+  background: #dbeafe;
+  color: #475569;
+}
+
+.detail-heart-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.detail-heart-button img {
+  width: 24px;
+  height: 24px;
+}
+
+.detail-brand-line {
+  margin: 14px 0 0;
+  color: #191c1e;
+  font-size: 16px;
+}
+
+.detail-product-title {
+  margin: 8px 0 0;
+  color: #191c1e;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.detail-price-block {
+  display: flex;
+  flex-direction: column;
+  margin-top: 18px;
+  color: #000;
+}
+
+.detail-price-block span {
+  font-size: 12px;
+}
+
+.detail-price-block strong {
+  margin-top: 4px;
+  font-size: 40px;
+  font-weight: 700;
+}
+
+.detail-price-meta,
+.detail-time-left {
+  margin: 10px 0 0;
+}
+
+.detail-price-meta {
+  color: #64748b;
+  font-size: 14px;
+}
+
+.detail-time-left {
+  color: #ef4444;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.detail-bid-box {
+  margin-top: 20px;
+}
+
+.detail-bid-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: #191c1e;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.detail-bid-field input {
+  width: 100%;
+  border: 0;
+  border-radius: 12px;
+  background: #f2f4f6;
+  padding: 14px 16px;
+  color: #191c1e;
+  font-size: 16px;
+}
+
+.detail-bid-button,
+.back-to-list {
+  width: 100%;
+  border: 0;
+  border-radius: 12px;
+  padding: 14px 16px;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.detail-bid-button {
+  margin-top: 14px;
+  background: #23008d;
+  color: #fff;
+}
+
+.detail-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.detail-stats div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: #475569;
+  font-size: 14px;
+}
+
+.detail-stats strong {
+  color: #191c1e;
+  font-weight: 600;
+}
+
+.history-panel {
+  padding: 20px;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.history-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 14px;
+  align-items: center;
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 12px 14px;
+  color: #64748b;
+  font-size: 13px;
+}
+
+.history-row strong {
+  color: #191c1e;
+}
+
+.back-to-list {
+  background: #f3f6fe;
+  color: #23008d;
+}
+
+.register-header h2,
+.register-header p,
+.inspection-header h2,
+.inspection-header p {
+  margin: 0;
+}
+
+.register-header h2,
+.inspection-header h2 {
+  color: #191c1e;
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.register-header p,
+.inspection-header p {
+  margin-top: 8px;
+  color: #64748b;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.register-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.register-card {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: 300px;
+  border-radius: 20px;
+  background: #fff;
+  padding: 28px;
+  box-shadow: 0 12px 32px -4px rgba(25, 28, 30, 0.06);
+}
+
+.register-card.is-inspection {
+  background: linear-gradient(180deg, #ffffff 0%, #f7fff9 100%);
+}
+
+.register-card.is-direct {
+  background: linear-gradient(180deg, #ffffff 0%, #f7f8ff 100%);
+}
+
+.register-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: #23008d;
+  color: #fff;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.register-card strong {
+  color: #191c1e;
+  font-size: 24px;
+  line-height: 1.4;
+}
+
+.register-card p {
+  margin: 0;
+  color: #64748b;
+  font-size: 15px;
+  line-height: 1.8;
+}
+
+.register-button,
+.inspection-action {
+  align-self: flex-start;
+  border: 0;
+  border-radius: 14px;
+  background: #23008d;
+  padding: 14px 18px;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.inspection-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.inspection-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.inspection-summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-radius: 18px;
+  background: #fff;
+  padding: 20px;
+  box-shadow: 0 12px 32px -4px rgba(25, 28, 30, 0.06);
+}
+
+.inspection-summary-card span {
+  color: #64748b;
+  font-size: 14px;
+}
+
+.inspection-summary-card strong {
+  color: #191c1e;
+  font-size: 28px;
+}
+
+.inspection-summary-card.is-review {
+  border-left: 4px solid #f59e0b;
+}
+
+.inspection-summary-card.is-complete {
+  border-left: 4px solid #22c55e;
+}
+
+.inspection-summary-card.is-ready {
+  border-left: 4px solid #23008d;
+}
+
+.inspection-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 216px);
+  gap: 30px;
+}
+
+@media (max-width: 1340px) {
+  .topbar,
+  .content {
+    padding-right: 40px;
+    padding-left: 40px;
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(2, 216px);
+  }
+
+  .list-screen {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .list-grid {
+    grid-template-columns: repeat(2, 216px);
+  }
+
+  .detail-grid,
+  .detail-title-row {
+    width: 100%;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .inspection-card-grid {
+    grid-template-columns: repeat(2, 216px);
+  }
+}
+
+@media (max-width: 980px) {
+  .page-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    min-height: auto;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .navigation {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .nav-item.is-active {
+    border-right: 0;
+    border-bottom: 4px solid var(--brand-color);
+    border-radius: 12px;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .list-screen {
+    grid-template-columns: 1fr;
+  }
+
+  .category-column {
+    border-right: 0;
+    border-bottom: 1px solid #f2f4f6;
+    padding-right: 0;
+    padding-bottom: 12px;
+  }
+
+  .list-column {
+    width: 100%;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .register-grid,
+  .inspection-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-title-row,
+  .inspection-header,
+  .seller-card,
+  .inquiry-summary-left {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .list-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .list-search {
+    width: 100%;
+  }
+
+  .top-links {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 720px) {
+  .topbar,
+  .content {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .hero-copy {
+    padding: 28px;
+  }
+
+  .hero-copy h2 {
+    font-size: 36px;
+    line-height: 1.15;
+  }
+
+  .hero-copy p {
+    font-size: 15px;
+    line-height: 1.7;
+  }
+
+  .card-grid,
+  .list-grid,
+  .inspection-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-product-title {
+    font-size: 28px;
+  }
+
+  .detail-image-card {
+    height: 280px;
+  }
+
+  .history-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -971,6 +971,247 @@ img {
   box-shadow: 0 14px 34px -14px rgba(0, 0, 0, 0.25);
 }
 
+.detail-bid-modal {
+  width: min(504px, 100%);
+  border-radius: 20px;
+  background: #fff;
+  padding: 30px;
+  box-shadow: 0 14px 34px -14px rgba(0, 0, 0, 0.25);
+}
+
+.detail-history-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 39;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(0, 0, 0, 0.46);
+}
+
+.detail-history-drawer {
+  display: flex;
+  flex-direction: column;
+  width: min(477px, 100%);
+  min-height: 100vh;
+  background: #fff;
+  padding: 24px 30px 20px;
+  box-shadow: -12px 0 32px rgba(15, 23, 42, 0.16);
+}
+
+.detail-history-drawer-top {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.detail-history-drawer-close {
+  border: 0;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.detail-history-drawer-summary {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 6px;
+}
+
+.detail-history-table {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  margin-top: 28px;
+}
+
+.detail-history-table-head,
+.detail-history-table-row {
+  display: grid;
+  grid-template-columns: 117px 112px 1fr;
+  align-items: center;
+}
+
+.detail-history-table-head {
+  height: 48px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-align: center;
+}
+
+.detail-history-table-body {
+  flex: 1;
+  overflow: auto;
+}
+
+.detail-history-table-row {
+  min-height: 48px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  color: #000;
+  font-size: 14px;
+  letter-spacing: 0.25px;
+}
+
+.detail-history-table-row span,
+.detail-history-table-row strong {
+  padding: 10px 16px;
+}
+
+.detail-history-table-row span:first-child {
+  text-align: center;
+}
+
+.detail-history-table-row strong {
+  color: #000;
+  font-weight: 400;
+  text-align: right;
+}
+
+.detail-history-table-row span:last-child {
+  text-align: left;
+}
+
+.detail-history-action {
+  width: 100%;
+  height: 44px;
+  margin-top: 24px;
+  border: 0;
+  border-radius: 10px;
+  background: #23008d;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.detail-bid-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.detail-bid-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  color: #000;
+  font-size: 14px;
+  line-height: 22px;
+  letter-spacing: 0.1px;
+}
+
+.detail-bid-meta-row strong {
+  font-size: 16px;
+  font-weight: 400;
+}
+
+.detail-bid-modal-label {
+  color: #000;
+  font-size: 14px;
+  line-height: 22px;
+}
+
+.detail-bid-input-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 41px;
+  border-bottom: 1px solid #94a3b8;
+  padding: 8px 12px;
+}
+
+.detail-bid-input-row input {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: #000;
+  font-size: 16px;
+  outline: none;
+}
+
+.detail-bid-input-row input::placeholder {
+  color: #9ca3af;
+}
+
+.detail-bid-input-row span {
+  color: #000;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 24px;
+}
+
+.detail-bid-quick-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.detail-bid-quick-chip {
+  min-width: 62px;
+  height: 28px;
+  border: 1px solid #9ca3af;
+  border-radius: 999px;
+  background: #fff;
+  padding: 0 14px;
+  color: #000;
+  font-family: 'Manrope', 'Noto Sans KR', sans-serif;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.detail-bid-modal-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  width: 100%;
+}
+
+.detail-buy-now-button,
+.detail-bid-submit-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  border: 0;
+  border-radius: 10px;
+  color: #fff;
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.detail-buy-now-button {
+  flex-direction: column;
+  gap: 0;
+  background: #bc1d25;
+}
+
+.detail-buy-now-button span {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+}
+
+.detail-buy-now-button strong {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 18px;
+}
+
+.detail-bid-submit-button {
+  background: #23008d;
+  font-size: 15px;
+  font-weight: 600;
+}
+
 .detail-inquiry-header {
   display: flex;
   align-items: center;
@@ -1440,8 +1681,7 @@ img {
   font-size: 16px;
 }
 
-.detail-bid-button,
-.back-to-list {
+.detail-bid-button {
   width: 100%;
   border: 0;
   border-radius: 12px;
@@ -1482,6 +1722,13 @@ img {
   padding: 20px;
 }
 
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
 .history-list {
   display: flex;
   flex-direction: column;
@@ -1505,9 +1752,14 @@ img {
   color: #191c1e;
 }
 
-.back-to-list {
-  background: #f3f6fe;
+.history-view-all {
+  border: 0;
+  background: transparent;
   color: #23008d;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+  cursor: pointer;
 }
 
 .inspection-header h2,

--- a/src/views/AuctionDetailView.vue
+++ b/src/views/AuctionDetailView.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { computed, watchEffect } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import AuctionDetailScreen from '../components/AuctionDetailScreen.vue'
+import { assets, findAuctionItemById } from '../data/marketplaceData'
+
+const route = useRoute()
+const router = useRouter()
+
+const selectedItem = computed(() => findAuctionItemById(String(route.params.id)))
+
+watchEffect(() => {
+  if (!selectedItem.value) {
+    router.replace('/auctions')
+  }
+})
+
+function backToList() {
+  router.push('/auctions')
+}
+</script>
+
+<template>
+  <AuctionDetailScreen
+    v-if="selectedItem"
+    :assets="assets"
+    :item="selectedItem"
+    @back="backToList"
+  />
+</template>

--- a/src/views/AuctionListView.vue
+++ b/src/views/AuctionListView.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { useRouter } from 'vue-router'
+import AuctionListScreen from '../components/AuctionListScreen.vue'
+import { assets, categoryGroups, listItems } from '../data/marketplaceData'
+
+const router = useRouter()
+
+function openDetail(item) {
+  router.push(`/auctions/${item.id}`)
+}
+</script>
+
+<template>
+  <AuctionListScreen
+    :assets="assets"
+    :categories="categoryGroups"
+    :items="listItems"
+    @open-detail="openDetail"
+  />
+</template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,0 +1,24 @@
+<script setup>
+import { useRouter } from 'vue-router'
+import HomeScreen from '../components/HomeScreen.vue'
+import { assets, bestItems } from '../data/marketplaceData'
+
+const router = useRouter()
+
+function openDetail(item) {
+  router.push(`/auctions/${item.id}`)
+}
+
+function openList() {
+  router.push('/auctions')
+}
+</script>
+
+<template>
+  <HomeScreen
+    :assets="assets"
+    :items="bestItems"
+    @open-detail="openDetail"
+    @open-list="openList"
+  />
+</template>

--- a/src/views/InspectionView.vue
+++ b/src/views/InspectionView.vue
@@ -1,0 +1,25 @@
+<script setup>
+import { useRouter } from 'vue-router'
+import InspectionScreen from '../components/InspectionScreen.vue'
+import { assets, inspectionItems, inspectionSummary } from '../data/marketplaceData'
+
+const router = useRouter()
+
+function openRegister(mode = 'inspection') {
+  router.push({
+    path: '/register',
+    query: {
+      mode,
+    },
+  })
+}
+</script>
+
+<template>
+  <InspectionScreen
+    :assets="assets"
+    :items="inspectionItems"
+    :summary="inspectionSummary"
+    @open-register="openRegister"
+  />
+</template>

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -1,0 +1,18 @@
+<script setup>
+import MyPageScreen from '../components/MyPageScreen.vue'
+import {
+  assets,
+  mypageBidItems,
+  mypageProfile,
+  mypagePurchaseItems,
+} from '../data/marketplaceData'
+</script>
+
+<template>
+  <MyPageScreen
+    :assets="assets"
+    :profile="mypageProfile"
+    :bid-items="mypageBidItems"
+    :purchase-items="mypagePurchaseItems"
+  />
+</template>

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -1,0 +1,17 @@
+<script setup>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import RegisterScreen from '../components/RegisterScreen.vue'
+
+const route = useRoute()
+const allowedModes = ['select', 'inspection', 'inspection-pick', 'direct', 'direct-auction']
+
+const initialMode = computed(() => {
+  const mode = typeof route.query.mode === 'string' ? route.query.mode : 'select'
+  return allowedModes.includes(mode) ? mode : 'select'
+})
+</script>
+
+<template>
+  <RegisterScreen :initial-mode="initialMode" />
+</template>


### PR DESCRIPTION
## 📌 PR 유형
- [x] Feature (새로운 기능 추가)
- [x] Fix (버그 수정)
- [ ] Refactor (코드 리팩토링)
- [ ] Chore (유지보수, 의존성 업데이트 등)
- [ ] Docs (문서 작성/수정)

---

## 📝 작업 내용
- `test-frontend`를 `biddinggo-frontend` 디자인 기준으로 정리하고 주요 화면 스타일을 맞춤
- `test-backend`에 이식한 기능을 `test-frontend`에서도 사용할 수 있도록 API 연동 추가
- 등록 화면에서 카테고리 조회 API를 사용하도록 변경하고, 최하위 카테고리만 선택 가능하게 수정
- 마이페이지에서 내 정보, 입찰 내역, 구매 내역, 포인트 내역 조회가 가능하도록 연결
- 마이페이지에 포인트 충전 UI를 추가하고 가상계좌 발급/입금 대기 계좌 조회 기능 연결
- 경매 상세 화면의 입찰 버튼/입찰 모달 동작을 수정하고, 로그인 여부에 따라 인증 기반 또는 `memberId` fallback 방식으로 입찰 요청이 가능하도록 보완
- `biddinggo-frontend`에서는 마이페이지 라우트, 상단 진입 버튼, 관련 컴포넌트 및 더미 데이터를 제거

---

## 📎 관련 이슈
- Closes #1
